### PR TITLE
JENKINS-13504: use the HTTP timeout inside the connection 

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/FitnesseExecutor.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseExecutor.java
@@ -194,7 +194,8 @@ public class FitnesseExecutor {
 				} catch (Exception e) {
 					// swallow - file may not exist
 				}
-				final byte[] bytes = getHttpBytes(logger, readFromURL, runnerWithTimeOut);
+				final byte[] bytes = getHttpBytes(logger, readFromURL, runnerWithTimeOut,
+						builder.getFitnesseHttpTimeout());
 				writeFitnesseResults(logger, writeToFilePath, bytes); 
 			}
 		};
@@ -208,13 +209,14 @@ public class FitnesseExecutor {
 		runnerWithTimeOut.run(readAndWriteResults, logToConsole);
 	}
 	
-	public byte[] getHttpBytes(PrintStream log, URL pageCmdTarget, Resettable timeout) {
+	public byte[] getHttpBytes(PrintStream log, URL pageCmdTarget, Resettable timeout, int httpTimeout) {
 		InputStream inputStream = null;
 		ByteArrayOutputStream bucket = new ByteArrayOutputStream();
 
 		try {
 			log.println("Connnecting to " + pageCmdTarget);
 			HttpURLConnection connection = (HttpURLConnection) pageCmdTarget.openConnection();
+			connection.setReadTimeout(httpTimeout);
 			log.println("Connected: " + connection.getResponseCode() + "/" + connection.getResponseMessage());
 
 			inputStream = connection.getInputStream();

--- a/src/test/java/hudson/plugins/fitnesse/FitnesseExecutorTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/FitnesseExecutorTest.java
@@ -2,6 +2,8 @@ package hudson.plugins.fitnesse;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -12,9 +14,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 public class FitnesseExecutorTest {
 
@@ -215,7 +214,8 @@ public class FitnesseExecutorTest {
 		Resettable resettable = new Resettable() {
 			public void reset() { resetWasCalled = true; }
 		};
-		byte[] bytes = executor.getHttpBytes(new PrintStream(logBucket), new URL("http://hudson-ci.org/"), resettable);
+		byte[] bytes = executor.getHttpBytes(new PrintStream(logBucket), new URL("http://hudson-ci.org/"),
+				resettable, 60*1000);
 		Assert.assertTrue(bytes.length > 0);
 		Assert.assertTrue(new String(bytes).contains("<html"));
 		Assert.assertTrue(new String(bytes).contains("</html>"));


### PR DESCRIPTION
Hi,

Here is a small patch to use the defined HTTP timeout for remote tests execution as a timeout for the connection. This is useful if the default HTTP read timeout of the JVM has been defined.

Best regards,
Reynald
