### PR TITLE
This class must implements Describable 

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResultsRecorder.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResultsRecorder.java
@@ -5,6 +5,7 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Action;
 import hudson.model.BuildListener;
+import hudson.model.Describable;
 import hudson.model.ModelObject;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
@@ -36,7 +37,7 @@ import javax.xml.transform.TransformerException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-public class FitnesseResultsRecorder extends Recorder {
+public class FitnesseResultsRecorder extends Recorder implements Describable<Publisher> {
 
 	private final String fitnessePathToXmlResultsIn;
 


### PR DESCRIPTION
This class must implement Describable otherwise Fitnesse -sometime- can't launch the plugin

I have the exception: 
java.lang.AssertionError: class hudson.plugins.fitnesse.FitnesseBuilder is missing its descriptor
        at jenkins.model.Jenkins.getDescriptorOrDie(Jenkins.java:1165)
        at hudson.tasks.Builder.getDescriptor(Builder.java:67)
        at hudson.plugins.fitnesse.FitnesseBuilder.getDescriptor(FitnesseBuilder.java:278)

See https://wiki.jenkins-ci.org/display/JENKINS/My+class+is+missing+descriptor 
