### PR TITLE
JENKINS-26387: Since version 1.9, you can’t run only a test (always check “Is target a suite”)

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/CompoundFitnesseResults.java
+++ b/src/main/java/hudson/plugins/fitnesse/CompoundFitnesseResults.java
@@ -28,7 +28,7 @@ public class CompoundFitnesseResults extends FitnesseResults {
 			duration += fitnesseResults.getDuration();
 		}
 		
-		Counts counts = new Counts(page, resultsDate, right, wrong, ignored, exceptions, duration, null);
+		Counts counts = new Counts(page, resultsDate, right, wrong, ignored, exceptions, duration, null, page);
 		return new CompoundFitnesseResults(resultsList, counts);
 	}
 	

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
@@ -297,14 +297,15 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 	
 	/**
-	 * referenced in body.jelly
+	 * referenced in body.jelly. Forward to the test page on fitnesse server.
 	 */
 	public String toHtml(FitnesseResults results) {
 		FitnesseBuildAction buildAction = getOwner().getAction(FitnesseBuildAction.class);
 		if (buildAction == null) {
 			buildAction = FitnesseBuildAction.NULL_ACTION;
 		}
-		return buildAction.getLinkFor(results.getName(), Hudson.getInstance().getRootUrl());
+//		return buildAction.getLinkFor(results.getName(), Hudson.getInstance().getRootUrl());
+		return buildAction.getLinkFor(results.getFitnessePage(), Hudson.getInstance().getRootUrl());
 	}
 
 	/**
@@ -323,6 +324,13 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 	
 	/**
+	 * Get the page name as used by fitnesse server.
+	 */
+	public String getFitnessePage(){
+		return pageCounts.fitnessePage;
+	}
+	
+	/**
 	 * referenced in body.jelly. 
 	 * The link points to the history of the fitnesse server. Note the history may not always be available.
 	 */
@@ -331,7 +339,13 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 		if (buildAction == null) {
 			buildAction = FitnesseBuildAction.NULL_ACTION;
 		}
-		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate="+getResultsDate(), null, "Details");
+//		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate="+getResultsDate(), null, "Details");
+		if( null == getResultsDate() || getResultsDate().equals("")) {
+			// if no history date is given, just forward to the history page
+			return buildAction.getLinkFor(getFitnessePage() + "?testHistory", null, "Details");
+		} else {
+			return buildAction.getLinkFor(getFitnessePage() + "?pageHistory&resultDate="+getResultsDate(), null, "Details");
+		}
 	}
 
 	@Override

--- a/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
+++ b/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
@@ -29,6 +29,9 @@ public class NativePageCounts extends DefaultHandler {
 	public static final String DURATION = "duration";
 	public static final String SUMMARY = "summary";
 	public static final String DETAIL = "detail";
+	// testResults/rootPath required for fitnesse-tests where the pageHistoryLink is not given 
+	public static final String ROOT_PATH = "rootPath";
+	
 	private static final List<String> COUNTABLE = Arrays.asList(new String[] {
 			SUMMARY, DETAIL });
 
@@ -61,6 +64,8 @@ public class NativePageCounts extends DefaultHandler {
 			String page = attributes.getValue(PAGE);
 			String pseudoPage = attributes.getValue(PSEUDO_PAGE);
 			String targetPage = page == null || page.equals("") ? pseudoPage : page;
+			// see JENKINS-26387 -> for fitnesse-tests the page name may be empty
+			String fitnessePage = (page == null || page.equals("") ? attributes.getValue(ROOT_PATH) : page);
 
 			Counts counts = new Counts(
 					targetPage,
@@ -70,7 +75,8 @@ public class NativePageCounts extends DefaultHandler {
 					Integer.parseInt(attributes.getValue(IGNORED)),
 					Integer.parseInt(attributes.getValue(EXCEPTIONS)), 
 					Integer.parseInt(attributes.getValue(DURATION)),
-					writeFitnesseResultFiles(targetPage, attributes.getValue(CONTENT))
+					writeFitnesseResultFiles(fitnessePage, attributes.getValue(CONTENT)), 
+					fitnessePage
 			);
 
 			if (qName.equals(SUMMARY))
@@ -142,9 +148,13 @@ public class NativePageCounts extends DefaultHandler {
 
 		// stores the file-path where to find the actual fitnesse result (html)
 		public final String contentFile;
+		
+		// points to the actual fitnesse page on the fitnesse server. Required for the links to the fitnesse server
+		// see JENKINS-26387
+		public final String fitnessePage; 
 
 		public Counts(String page, String resultsDate, int right, int wrong, int ignored,
-		    int exceptions, int duration, String contentFile) {
+		    int exceptions, int duration, String contentFile, String fitnessePage) {
 			this.page = page;
 			this.resultsDate = resultsDate;
 			this.right = right;
@@ -156,6 +166,7 @@ public class NativePageCounts extends DefaultHandler {
 			if (contentFile != null) {
 				content = "";
 			}
+			this.fitnessePage = fitnessePage;
 		}
 
 		public Date resultsDateAsDate() throws ParseException {

--- a/src/main/java/hudson/plugins/fitnesse/ResultsDetails.java
+++ b/src/main/java/hudson/plugins/fitnesse/ResultsDetails.java
@@ -82,17 +82,21 @@ public class ResultsDetails extends TestResult {
 		StringBuffer ret = new StringBuffer();
 		// get the saved filename including its path
 		String fileName = parentResults.getPageCounts().contentFile;
+		log.info("getDetailsHtml-> filename: " + fileName);
 		if (fileName == null) {
 			return "error, content filename is null for page " + parentResults.getName();
 		}
 		BufferedReader br = null;
 		try {
+			log.info("getDetailsHtml-> start reading");
 			br = new BufferedReader(new FileReader(fileName));
 			String strLine;
 			while ((strLine = br.readLine()) != null) {
 				ret.append(strLine);
 			}
+			log.info("getDetailsHtml-> finished reading");
 		} catch (IOException e) {
+			log.info("error while reading: "+ e.toString());
 			return "exception while reading file: " + fileName + "\n"
 					+ e.toString();
 		} finally {

--- a/src/main/resources/hudson/plugins/fitnesse/fitnesse-results.xsl
+++ b/src/main/resources/hudson/plugins/fitnesse/fitnesse-results.xsl
@@ -48,6 +48,9 @@
 		<xsl:attribute name="name">
 			<xsl:value-of select="relativePageName"/>
 		</xsl:attribute>
+		<xsl:attribute name="rootPath">
+			<xsl:value-of select="../rootPath"/>
+		</xsl:attribute>				
 		<xsl:attribute name="right">
 			<xsl:value-of select="counts/right"/>
 		</xsl:attribute>

--- a/src/test/java/hudson/plugins/fitnesse/FitnesseResultsTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/FitnesseResultsTest.java
@@ -46,7 +46,7 @@ public class FitnesseResultsTest {
 
 	private static FitnesseResults resultsForCounts(int right, int wrong, int ignored, int exceptions) {
 		return new FitnesseResults(new Counts("", "20100320184439", right, wrong, ignored, exceptions,
-		    0, null));
+		    0, null, ""));
 	}
 	
 	@Test
@@ -132,8 +132,8 @@ public class FitnesseResultsTest {
 		return summary;
 	}
 
-	private static final Counts BEFORE = new Counts("", "20100313174438", 1, 2, 3, 4, 0, null);
-	private static final Counts AFTER = new Counts("", "20100313174439", 1, 2, 3, 4, 0, null);
+	private static final Counts BEFORE = new Counts("", "20100313174438", 1, 2, 3, 4, 0, null, "");
+	private static final Counts AFTER = new Counts("", "20100313174439", 1, 2, 3, 4, 0, null, "");
 	
 	@Test
 	public void isEarlierThanShouldDependOnCounts() {

--- a/src/test/java/hudson/plugins/fitnesse/NativePageCountsTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/NativePageCountsTest.java
@@ -15,7 +15,7 @@ public class NativePageCountsTest {
 	@Test
 	public void countsShouldCollectValuesFromConstructor() {
 		String contentFileName = "./fileName";
-		Counts actual = new Counts("name", "201003112307", 1, 2, 3, 4, 5, contentFileName);
+		Counts actual = new Counts("name", "201003112307", 1, 2, 3, 4, 5, contentFileName, "name");
 		Assert.assertEquals("name", actual.page);
 		Assert.assertEquals(1, actual.right);
 		Assert.assertEquals(2, actual.wrong);
@@ -27,7 +27,7 @@ public class NativePageCountsTest {
 
 	@Test
 	public void countsToStringShouldSpellOutValues() {
-		Counts actual = new Counts("name", "2010xxxx", 11, 10, 9, 8, 7, null);
+		Counts actual = new Counts("name", "2010xxxx", 11, 10, 9, 8, 7, null, "name");
 		Assert.assertEquals("name (2010xxxx): 11 right, 10 wrong, 9 ignored, 8 exceptions, in 7 ms",
 				actual.toString());
 	}
@@ -38,7 +38,7 @@ public class NativePageCountsTest {
 		calendar.clear(Calendar.MILLISECOND);
 		Date aDate = calendar.getTime();
 		Counts actual = new Counts("name", Counts.RESULTS_DATE_FORMAT.format(aDate), 11, 10, 9, 8, 7,
-		    null);
+		    null, "name");
 		Assert.assertEquals(aDate, actual.resultsDateAsDate());
 	}
 	
@@ -97,6 +97,7 @@ public class NativePageCountsTest {
 		Assert.assertEquals(8, results.getDetails().get(0).exceptions);
 		Assert.assertEquals(9, results.getDetails().get(0).duration);
 		Assert.assertEquals("./target/name", results.getDetails().get(0).contentFile);
+		Assert.assertNotNull(results.getDetails().get(0).fitnessePage);
 	}
 
 	private void addDetailAttributes(AttributesImpl attributes,
@@ -125,5 +126,6 @@ public class NativePageCountsTest {
 		Assert.assertEquals(2, results.size());
 		Assert.assertEquals(1, results.getDetails().size());
 		Assert.assertSame(results.getSummary(), results.getDetails().get(0));
+		Assert.assertNotNull(results.getDetails().get(0).fitnessePage);
 	}
 }


### PR DESCRIPTION
The issue is the difference in the fitnesse response xml.
The jenkins-fitnesse-plugin retrieves the fitnesse-test-page from the pageHistoryLink xml-node which is missing for fitnesse-tests