### PR TITLE
Added fix for issue with css loading if jenkins isn't ROOT application

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/ResultsDetails.java
+++ b/src/main/java/hudson/plugins/fitnesse/ResultsDetails.java
@@ -1,6 +1,7 @@
 package hudson.plugins.fitnesse;
 
 import static java.util.Collections.emptyList;
+import jenkins.model.Jenkins;
 import hudson.model.AbstractBuild;
 import hudson.plugins.fitnesse.NativePageCounts.Counts;
 import hudson.tasks.test.AbstractTestResultAction;
@@ -71,6 +72,13 @@ public class ResultsDetails extends TestResult {
 			return this;
 
 		return null;
+	}
+
+	/**
+	 * referenced from body.jelly Returns Jenkins root URL to form correct paths to static resources
+	 */
+	public String getRootUrlFromRequest() {
+		return Jenkins.getInstance().getRootUrlFromRequest();
 	}
 
 	/**

--- a/src/main/resources/hudson/plugins/fitnesse/ResultsDetails/body.jelly
+++ b/src/main/resources/hudson/plugins/fitnesse/ResultsDetails/body.jelly
@@ -1,6 +1,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
 	xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
 	xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-	<link rel="stylesheet" href="/plugin/fitnesse/css/fitnesse_results.css" type="text/css"/>
+	<link rel="stylesheet" href="${it.getRootUrlFromRequest()}/plugin/fitnesse/css/fitnesse_results.css" type="text/css"/>
 	<div id="fitnesse_results">${it.getDetailsHtml()}</div>	
 </j:jelly>


### PR DESCRIPTION
Browser looks for fitnesse_results.css using the '/fitnesse/css/fitnesse_results.css' relative to server path.
If Jenkins is installed as ROOT application onto a server, it works fine, but if Jenkins is installed as an addition application, for example in 'jenkins' subfolder, the file is available at http://server/jenkins/fitnesse/css/fitnesse_results.css, but the results page still uses http://server/fitnesse/css/fitnesse_results.css path. In result, dev/qa see the page without css, and it's badly readable.
This fix determines URL to the application from request and generates css file location based on it.