### PR TITLE
Fix JENKINS-26387: can't run a test page only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 target
 work
 /bin
+/target/

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
@@ -22,12 +22,12 @@ import org.kohsuke.stapler.export.Exported;
 public class FitnesseResults extends TabulatedResult implements Comparable<FitnesseResults>{
 	private static final String DETAILS = "Details";
 
-	// private static final Logger log = Logger.getLogger("FitNesse");
+	//private static final Logger log = Logger.getLogger(FitnesseResults.class.getName());
 	
 	private static final long serialVersionUID = 1L;
-	private transient List<FitnesseResults> failed = null;
-	private transient List<FitnesseResults> skipped = null;
-	private transient List<FitnesseResults> passed = null;
+	private transient List<FitnesseResults> failed;
+	private transient List<FitnesseResults> skipped;
+	private transient List<FitnesseResults> passed;
 	
 	private Counts pageCounts;
 	private TestObject parent;
@@ -334,14 +334,6 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate="+getResultsDate(), null, "Details");
 	}
 
-	@Override
-	public String getErrorDetails() {
-		if (pageCounts.content != null) {
-			return pageCounts.content;
-		}
-		return "";
-	}
-	
 	
 	/**
 	 * called from links embedded in history/trend graphs 
@@ -356,6 +348,7 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 		return findChildByName(token);
 	}
 
+	@SuppressWarnings("unchecked")
 	private <T extends TestResult> T findChildByName(String aName) {
 		Collection<? extends TestResult> children = getChildren();
 		for (TestResult child : children) {
@@ -415,24 +408,9 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	 * that is available via {@link #getHtmlContent()}
 	 */
 	protected boolean hasHtmlContent() {
-		return pageCounts != null && pageCounts.content != null;
+		return pageCounts != null && pageCounts.contentFile != null;
 	}
-	
-	/**
-	 * Returns the html content of this result.
-	 */
-	protected String getHtmlContent() {
-		if (hasHtmlContent()) {
-			return pageCounts.content;
-		}
-		return "";
-	}
-	
-	@Override
-	public String getStdout() {
-		return getHtmlContent();
-	}
-	
+
 	/**
 	 * Make page counts accessible to ResultsDetails
 	 */

--- a/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
+++ b/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
@@ -57,11 +57,16 @@ public class NativePageCounts extends DefaultHandler {
 	@Override
 	public void startElement(String uri, String localName, String qName,
 			Attributes attributes) {
-		if (COUNTABLE.contains(qName)) {
-			String page = attributes.getValue(PAGE);
-			String pseudoPage = attributes.getValue(PSEUDO_PAGE);
-			String targetPage = page == null || page.equals("") ? pseudoPage : page;
 
+		if (COUNTABLE.contains(qName)) {
+			String targetPage;
+			if (qName.equals(SUMMARY)) {
+				targetPage = "Summary";
+			} else {
+				String page = attributes.getValue(PAGE);
+				String pseudoPage = attributes.getValue(PSEUDO_PAGE);
+				targetPage = page == null || page.equals("") ? pseudoPage : page;
+			}
 			Counts counts = new Counts(
 					targetPage,
 					qName.equals(SUMMARY) ? "" : resultsDateOf(attributes.getValue(APPROX_RESULT_DATE)),
@@ -73,9 +78,11 @@ public class NativePageCounts extends DefaultHandler {
 					writeFitnesseResultFiles(targetPage, attributes.getValue(CONTENT))
 			);
 
-			if (qName.equals(SUMMARY))
-				summary = counts;
 			allCounts.put(counts.page, counts);
+
+			if (qName.equals(SUMMARY)) {
+				summary = counts;
+			}
 		}
 	}
 

--- a/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
+++ b/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
@@ -101,16 +101,6 @@ public class NativePageCounts extends DefaultHandler {
 		return summary;
 	}
 
-	public List<String> getDetailsContents() {
-		ArrayList<String> contents = new ArrayList<String>();
-		for (String key : allCounts.keySet()) {
-			Counts counts = allCounts.get(key);
-			if (counts != summary)
-				contents.add(counts.content);
-		}
-		return contents;
-	}
-
 	public Collection<Counts> getAllCounts() {
 		return allCounts.values();
 	}
@@ -126,7 +116,6 @@ public class NativePageCounts extends DefaultHandler {
 	}
 
 	static final class Counts {
-		private static final long serialVersionUID = 1L;
 		static final SimpleDateFormat RESULTS_DATE_FORMAT = new SimpleDateFormat(
 				"yyyyMMddHHmmss");
 
@@ -138,7 +127,7 @@ public class NativePageCounts extends DefaultHandler {
 		public final int exceptions;
 		public final int duration;
 
-		public String content; // TODO remove this useless field, use contentFile in tests
+		public String content; // not used, keep for backward compatibility
 
 		// stores the file-path where to find the actual fitnesse result (html)
 		public final String contentFile;
@@ -153,9 +142,6 @@ public class NativePageCounts extends DefaultHandler {
 			this.exceptions = exceptions;
 			this.duration = duration;
 			this.contentFile = contentFile;
-			if (contentFile != null) {
-				content = "";
-			}
 		}
 
 		public Date resultsDateAsDate() throws ParseException {

--- a/src/test/java/hudson/plugins/fitnesse/NativePageCountsParserTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/NativePageCountsParserTest.java
@@ -66,7 +66,7 @@ public class NativePageCountsParserTest {
 		NativePageCounts testResults = fitnesseParser.parse(toInputStream(RESULTS), System.out,
 		    "./target/");
 		Assert.assertEquals(2, testResults.size());
-		Assert.assertEquals("SuiteBlah", testResults.getSummary().page);
+		Assert.assertEquals("Summary", testResults.getSummary().page);
 		Assert.assertEquals(5, testResults.getSummary().right);
 		Assert.assertEquals(4, testResults.getSummary().wrong);
 		Assert.assertEquals(3, testResults.getSummary().ignored);
@@ -78,7 +78,7 @@ public class NativePageCountsParserTest {
 		NativePageCounts testResults = fitnesseParser.parse(toInputStream(RESULTS), System.out,
 		    "./target/");
 		Assert.assertEquals(2, testResults.size());
-		Assert.assertEquals("SuiteBlah", testResults.getSummary().page);
+		Assert.assertEquals("Summary", testResults.getSummary().page);
 		Assert.assertEquals(1, testResults.getDetails().size());
 	}
 	
@@ -87,7 +87,7 @@ public class NativePageCountsParserTest {
 		InputStream sampleXml = getClass().getResourceAsStream("fitnesse-suite-results.xml");
 		NativePageCounts testResults = fitnesseParser.parse(sampleXml, System.out, "./target/");
 		Assert.assertEquals(15, testResults.size());
-		Assert.assertEquals("SuiteBranchMain", testResults.getSummary().page);
+		Assert.assertEquals("Summary", testResults.getSummary().page);
 		Assert.assertEquals(6, testResults.getSummary().right);
 		Assert.assertEquals(5, testResults.getSummary().wrong);
 		Assert.assertEquals(1, testResults.getSummary().ignored);
@@ -99,7 +99,7 @@ public class NativePageCountsParserTest {
 	public void parserShouldCollectAllCountsFromSingleTestFile() throws Exception {
 		InputStream sampleXml = getClass().getResourceAsStream("fitnesse-test-results.xml");
 		NativePageCounts testResults = fitnesseParser.parse(sampleXml, System.out, "./target/");
-		Assert.assertEquals(1, testResults.size());
+		Assert.assertEquals(2, testResults.size());
 		Assert.assertEquals("TestDecisionTable", testResults.getSummary().page);
 		Assert.assertEquals(16, testResults.getSummary().right);
 		Assert.assertEquals(2, testResults.getSummary().wrong);

--- a/src/test/java/hudson/plugins/fitnesse/NativePageCountsParserTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/NativePageCountsParserTest.java
@@ -79,7 +79,7 @@ public class NativePageCountsParserTest {
 		    "./target/");
 		Assert.assertEquals(2, testResults.size());
 		Assert.assertEquals("SuiteBlah", testResults.getSummary().page);
-		Assert.assertEquals(1, testResults.getDetailsContents().size());
+		Assert.assertEquals(1, testResults.getDetails().size());
 	}
 	
 	@Test

--- a/src/test/java/hudson/plugins/fitnesse/NativePageCountsTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/NativePageCountsTest.java
@@ -58,7 +58,7 @@ public class NativePageCountsTest {
 		Assert.assertEquals(1, results.size());
 		Assert.assertNotNull(results.getSummary());
 		Assert.assertEquals(0, results.getDetails().size());
-		Assert.assertEquals("pseudo-name", results.getSummary().page);
+		Assert.assertEquals("Summary", results.getSummary().page);
 		Assert.assertEquals("", results.getSummary().resultsDate);
 		Assert.assertEquals(1, results.getSummary().right);
 		Assert.assertEquals(2, results.getSummary().wrong);


### PR DESCRIPTION
Rename base page for a 'not suite' test, otherwise we can't see detail of a test page because it use the base page which has the same name.

Fixed JENKINS-26387
