### PR TITLE
Change way of loading template to not base on plug-in start method

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/FitnessePlugin.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnessePlugin.java
@@ -16,16 +16,21 @@ public class FitnessePlugin extends Plugin {
 
 	@Override
 	public void start() throws Exception {
+	}
+
+	public static InputStream getXslAsInputStream() throws IOException {
+        InputStream inputstream = FitnessePlugin.class.getResourceAsStream("fitnesse-results.xsl");
+        if (inputstream == null) throw new IOException("Cannot get access to fitnesse-results.xsl");
+        return InputStreamDeBOMer.deBOM(inputstream);
+	}
+
+	public static Transformer newRawResultsTransformer() throws TransformerException, IOException {
+		if (templates != null)
+			return templates.newTransformer();
+
 		TransformerFactory transformerFactory = TransformerFactory.newInstance();
 		StreamSource xslSource = new StreamSource(getXslAsInputStream());
 		templates = transformerFactory.newTemplates(xslSource);
-	}
-
-	public InputStream getXslAsInputStream() throws IOException {
-		return InputStreamDeBOMer.deBOM(getClass().getResourceAsStream("fitnesse-results.xsl"));
-	}
-
-	public static Transformer newRawResultsTransformer() throws TransformerException {
 		return templates.newTransformer();
 	}
 

--- a/src/main/java/hudson/plugins/fitnesse/FitnessePlugin.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnessePlugin.java
@@ -16,21 +16,16 @@ public class FitnessePlugin extends Plugin {
 
 	@Override
 	public void start() throws Exception {
-	}
-
-	public static InputStream getXslAsInputStream() throws IOException {
-        InputStream inputstream = FitnessePlugin.class.getResourceAsStream("fitnesse-results.xsl");
-        if (inputstream == null) throw new IOException("Cannot get access to fitnesse-results.xsl");
-        return InputStreamDeBOMer.deBOM(inputstream);
-	}
-
-	public static Transformer newRawResultsTransformer() throws TransformerException, IOException {
-		if (templates != null)
-			return templates.newTransformer();
-
 		TransformerFactory transformerFactory = TransformerFactory.newInstance();
 		StreamSource xslSource = new StreamSource(getXslAsInputStream());
 		templates = transformerFactory.newTemplates(xslSource);
+	}
+
+	public InputStream getXslAsInputStream() throws IOException {
+		return InputStreamDeBOMer.deBOM(getClass().getResourceAsStream("fitnesse-results.xsl"));
+	}
+
+	public static Transformer newRawResultsTransformer() throws TransformerException {
 		return templates.newTransformer();
 	}
 

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
@@ -19,10 +19,12 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 
-public class FitnesseResults extends TabulatedResult implements Comparable<FitnesseResults> {
+public class FitnesseResults extends TabulatedResult implements
+		Comparable<FitnesseResults> {
 	private static final String DETAILS = "Details";
 
-	//private static final Logger log = Logger.getLogger(FitnesseResults.class.getName());
+	// private static final Logger log =
+	// Logger.getLogger(FitnesseResults.class.getName());
 
 	private static final long serialVersionUID = 1L;
 	private transient List<FitnesseResults> failed;
@@ -60,7 +62,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * {@link TestObject} Required to compare builds with one another e.g. show history graph
+	 * {@link TestObject} Required to compare builds with one another e.g. show
+	 * history graph
 	 */
 	@Override
 	public TestResult findCorrespondingResult(final String id) {
@@ -190,7 +193,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 
 	public boolean isEarlierThan(FitnesseResults other) {
 		try {
-			return pageCounts.resultsDateAsDate().before(other.pageCounts.resultsDateAsDate());
+			return pageCounts.resultsDateAsDate().before(
+					other.pageCounts.resultsDateAsDate());
 		} catch (ParseException e) {
 			return false;
 		}
@@ -198,7 +202,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 
 	public boolean isLaterThan(FitnesseResults other) {
 		try {
-			return pageCounts.resultsDateAsDate().after(other.pageCounts.resultsDateAsDate());
+			return pageCounts.resultsDateAsDate().after(
+					other.pageCounts.resultsDateAsDate());
 		} catch (ParseException e) {
 			return false;
 		}
@@ -206,7 +211,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 
 	public long millisAfter(FitnesseResults other) {
 		try {
-			return pageCounts.resultsDateAsDate().getTime() - other.pageCounts.resultsDateAsDate().getTime();
+			return pageCounts.resultsDateAsDate().getTime()
+					- other.pageCounts.resultsDateAsDate().getTime();
 		} catch (ParseException e) {
 			return 0;
 		}
@@ -220,9 +226,9 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * {@see TestObject#getTestResultAction()}
-	 * Required to prevent looking for any old AbstractTestResultAction
-	 * when e.g. looking for history across multiple builds 
+	 * {@see TestObject#getTestResultAction()} Required to prevent looking for
+	 * any old AbstractTestResultAction when e.g. looking for history across
+	 * multiple builds
 	 */
 	@Override
 	public FitnesseResultsAction getTestResultAction() {
@@ -230,13 +236,14 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * {@see TestResult#getParentAction()}
-	 * Required to prevent looking for any old AbstractTestResultAction
-	 * when e.g. looking for history across multiple builds 
+	 * {@see TestResult#getParentAction()} Required to prevent looking for any
+	 * old AbstractTestResultAction when e.g. looking for history across
+	 * multiple builds
 	 */
 	@Override
 	public FitnesseResultsAction getParentAction() {
-		FitnesseResultsAction action = getOwner().getAction(FitnesseResultsAction.class);
+		FitnesseResultsAction action = getOwner().getAction(
+				FitnesseResultsAction.class);
 		return action;
 	}
 
@@ -286,7 +293,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 		return skipped;
 	}
 
-	private List<FitnesseResults> filteredCopyOfDetails(ResultsFilter countsFilter) {
+	private List<FitnesseResults> filteredCopyOfDetails(
+			ResultsFilter countsFilter) {
 		List<FitnesseResults> filteredCopy = new ArrayList<FitnesseResults>();
 		for (FitnesseResults result : details) {
 			if (countsFilter.include(result)) {
@@ -305,43 +313,49 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	 * referenced in body.jelly
 	 */
 	public String toHtml(FitnesseResults results) {
-		FitnesseBuildAction buildAction = getOwner().getAction(FitnesseBuildAction.class);
+		FitnesseBuildAction buildAction = getOwner().getAction(
+				FitnesseBuildAction.class);
 		if (buildAction == null) {
 			buildAction = FitnesseBuildAction.NULL_ACTION;
 		}
-		return buildAction.getLinkFor(results.getName(), Hudson.getInstance().getRootUrl());
+		return buildAction.getLinkFor(results.getName(), Hudson.getInstance()
+				.getRootUrl());
 	}
 
 	/**
-	 * referenced in body.jelly. Link is apparently relative to 
-	 * This is the left column, which reads the results from file
+	 * referenced in body.jelly. Link is apparently relative to This is the left
+	 * column, which reads the results from file
 	 */
 	public String getDetailsLink() {
 		if (details == null) {
 			return "&nbsp;";
 		}
 
-		return String.format("<a href=\"%s/%s\">%s</a>", getName(), DETAILS, "Details");
+		return String.format("<a href=\"%s/%s\">%s</a>", getName(), DETAILS,
+				"Details");
 	}
 
 	/**
-	 * referenced in body.jelly. 
-	 * The link points to the history of the fitnesse server. Note the history may not always be available.
+	 * referenced in body.jelly. The link points to the history of the fitnesse
+	 * server. Note the history may not always be available.
 	 */
 	public String getDetailRemoteLink() {
-		FitnesseBuildAction buildAction = getOwner().getAction(FitnesseBuildAction.class);
+		FitnesseBuildAction buildAction = getOwner().getAction(
+				FitnesseBuildAction.class);
 		if (buildAction == null) {
 			buildAction = FitnesseBuildAction.NULL_ACTION;
 		}
-		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate=" + getResultsDate(), null, "Details");
+		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate="
+				+ getResultsDate(), null, "Details");
 	}
 
 	/**
-	 * called from links embedded in history/trend graphs 
-	 * TODO: Expose sub-suites as separate elements of the fitnesse report.
+	 * called from links embedded in history/trend graphs TODO: Expose
+	 * sub-suites as separate elements of the fitnesse report.
 	 */
 	@Override
-	public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+	public Object getDynamic(String token, StaplerRequest req,
+			StaplerResponse rsp) {
 		TestResult result = findCorrespondingResult(token);
 		if (result != null) {
 			return result;
@@ -362,9 +376,9 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * Returns <code>true</code> if there are child results available.
-	 * So far, only returns <code>true</code> if there is {@link #getHtmlContent()}
-	 * for this result available.
+	 * Returns <code>true</code> if there are child results available. So far,
+	 * only returns <code>true</code> if there is {@link #getHtmlContent()} for
+	 * this result available.
 	 */
 	@Override
 	public boolean hasChildren() {
@@ -372,8 +386,9 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * Returns the children of this result. Returns both the details and the html
-	 * content, if available.
+	 * Returns the children of this result. Returns both the details and the
+	 * html content, if available.
+	 * 
 	 * @return the details and html content results, or an empty Collection
 	 */
 	@Override
@@ -391,22 +406,24 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * Returns <code>true</code> if there are children FitNesse results available
+	 * Returns <code>true</code> if there are children FitNesse results
+	 * available
 	 */
 	protected boolean hasChildResults() {
 		return !getChildResults().isEmpty();
 	}
 
 	/**
-	 * Returns the children FitNesse results that were added with {@link #addChild(FitnesseResults)}
+	 * Returns the children FitNesse results that were added with
+	 * {@link #addChild(FitnesseResults)}
 	 */
 	protected List<FitnesseResults> getChildResults() {
 		return details;
 	}
 
 	/**
-	 * Returns <code>true</code> if this results has html content
-	 * that is available via {@link #getHtmlContent()}
+	 * Returns <code>true</code> if this results has html content that is
+	 * available via {@link #getHtmlContent()}	 
 	 */
 	protected boolean hasHtmlContent() {
 		return pageCounts != null && pageCounts.contentFile != null;

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
@@ -19,10 +19,12 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 
-public class FitnesseResults extends TabulatedResult implements Comparable<FitnesseResults> {
+public class FitnesseResults extends TabulatedResult implements
+		Comparable<FitnesseResults> {
 	private static final String DETAILS = "Details";
 
-	//private static final Logger log = Logger.getLogger(FitnesseResults.class.getName());
+	// private static final Logger log =
+	// Logger.getLogger(FitnesseResults.class.getName());
 
 	private static final long serialVersionUID = 1L;
 	private transient List<FitnesseResults> failed;
@@ -60,7 +62,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * {@link TestObject} Required to compare builds with one another e.g. show history graph
+	 * {@link TestObject} Required to compare builds with one another e.g. show
+	 * history graph
 	 */
 	@Override
 	public TestResult findCorrespondingResult(final String id) {
@@ -190,7 +193,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 
 	public boolean isEarlierThan(FitnesseResults other) {
 		try {
-			return pageCounts.resultsDateAsDate().before(other.pageCounts.resultsDateAsDate());
+			return pageCounts.resultsDateAsDate().before(
+					other.pageCounts.resultsDateAsDate());
 		} catch (ParseException e) {
 			return false;
 		}
@@ -198,7 +202,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 
 	public boolean isLaterThan(FitnesseResults other) {
 		try {
-			return pageCounts.resultsDateAsDate().after(other.pageCounts.resultsDateAsDate());
+			return pageCounts.resultsDateAsDate().after(
+					other.pageCounts.resultsDateAsDate());
 		} catch (ParseException e) {
 			return false;
 		}
@@ -206,7 +211,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 
 	public long millisAfter(FitnesseResults other) {
 		try {
-			return pageCounts.resultsDateAsDate().getTime() - other.pageCounts.resultsDateAsDate().getTime();
+			return pageCounts.resultsDateAsDate().getTime()
+					- other.pageCounts.resultsDateAsDate().getTime();
 		} catch (ParseException e) {
 			return 0;
 		}
@@ -220,9 +226,9 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * {@see TestObject#getTestResultAction()}
-	 * Required to prevent looking for any old AbstractTestResultAction
-	 * when e.g. looking for history across multiple builds 
+	 * {@see TestObject#getTestResultAction()} Required to prevent looking for
+	 * any old AbstractTestResultAction when e.g. looking for history across
+	 * multiple builds
 	 */
 	@Override
 	public FitnesseResultsAction getTestResultAction() {
@@ -230,13 +236,14 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * {@see TestResult#getParentAction()}
-	 * Required to prevent looking for any old AbstractTestResultAction
-	 * when e.g. looking for history across multiple builds 
+	 * {@see TestResult#getParentAction()} Required to prevent looking for any
+	 * old AbstractTestResultAction when e.g. looking for history across
+	 * multiple builds
 	 */
 	@Override
 	public FitnesseResultsAction getParentAction() {
-		FitnesseResultsAction action = getOwner().getAction(FitnesseResultsAction.class);
+		FitnesseResultsAction action = getOwner().getAction(
+				FitnesseResultsAction.class);
 		return action;
 	}
 
@@ -286,7 +293,8 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 		return skipped;
 	}
 
-	private List<FitnesseResults> filteredCopyOfDetails(ResultsFilter countsFilter) {
+	private List<FitnesseResults> filteredCopyOfDetails(
+			ResultsFilter countsFilter) {
 		List<FitnesseResults> filteredCopy = new ArrayList<FitnesseResults>();
 		for (FitnesseResults result : details) {
 			if (countsFilter.include(result)) {
@@ -305,43 +313,49 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	 * referenced in body.jelly
 	 */
 	public String toHtml(FitnesseResults results) {
-		FitnesseBuildAction buildAction = getOwner().getAction(FitnesseBuildAction.class);
+		FitnesseBuildAction buildAction = getOwner().getAction(
+				FitnesseBuildAction.class);
 		if (buildAction == null) {
 			buildAction = FitnesseBuildAction.NULL_ACTION;
 		}
-		return buildAction.getLinkFor(results.getName(), Hudson.getInstance().getRootUrl());
+		return buildAction.getLinkFor(results.getName(), Hudson.getInstance()
+				.getRootUrl());
 	}
 
 	/**
-	 * referenced in body.jelly. Link is apparently relative to 
-	 * This is the left column, which reads the results from file
+	 * referenced in body.jelly. Link is apparently relative to This is the left
+	 * column, which reads the results from file
 	 */
 	public String getDetailsLink() {
 		if (details == null) {
 			return "&nbsp;";
 		}
 
-		return String.format("<a href=\"%s/%s\">%s</a>", getName(), DETAILS, "Details");
+		return String.format("<a href=\"%s/%s\">%s</a>", getName(), DETAILS,
+				"Details");
 	}
 
 	/**
-	 * referenced in body.jelly. 
-	 * The link points to the history of the fitnesse server. Note the history may not always be available.
+	 * referenced in body.jelly. The link points to the history of the fitnesse
+	 * server. Note the history may not always be available.
 	 */
 	public String getDetailRemoteLink() {
-		FitnesseBuildAction buildAction = getOwner().getAction(FitnesseBuildAction.class);
+		FitnesseBuildAction buildAction = getOwner().getAction(
+				FitnesseBuildAction.class);
 		if (buildAction == null) {
 			buildAction = FitnesseBuildAction.NULL_ACTION;
 		}
-		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate=" + getResultsDate(), null, "Details");
+		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate="
+				+ getResultsDate(), null, "Details");
 	}
 
 	/**
-	 * called from links embedded in history/trend graphs 
-	 * TODO: Expose sub-suites as separate elements of the fitnesse report.
+	 * called from links embedded in history/trend graphs TODO: Expose
+	 * sub-suites as separate elements of the fitnesse report.
 	 */
 	@Override
-	public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+	public Object getDynamic(String token, StaplerRequest req,
+			StaplerResponse rsp) {
 		TestResult result = findCorrespondingResult(token);
 		if (result != null) {
 			return result;
@@ -362,9 +376,9 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * Returns <code>true</code> if there are child results available.
-	 * So far, only returns <code>true</code> if there is {@link #getHtmlContent()}
-	 * for this result available.
+	 * Returns <code>true</code> if there are child results available. So far,
+	 * only returns <code>true</code> if there is {@link #getHtmlContent()} for
+	 * this result available.
 	 */
 	@Override
 	public boolean hasChildren() {
@@ -372,8 +386,9 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * Returns the children of this result. Returns both the details and the html
-	 * content, if available.
+	 * Returns the children of this result. Returns both the details and the
+	 * html content, if available.
+	 * 
 	 * @return the details and html content results, or an empty Collection
 	 */
 	@Override
@@ -391,22 +406,24 @@ public class FitnesseResults extends TabulatedResult implements Comparable<Fitne
 	}
 
 	/**
-	 * Returns <code>true</code> if there are children FitNesse results available
+	 * Returns <code>true</code> if there are children FitNesse results
+	 * available
 	 */
 	protected boolean hasChildResults() {
 		return !getChildResults().isEmpty();
 	}
 
 	/**
-	 * Returns the children FitNesse results that were added with {@link #addChild(FitnesseResults)}
+	 * Returns the children FitNesse results that were added with
+	 * {@link #addChild(FitnesseResults)}
 	 */
 	protected List<FitnesseResults> getChildResults() {
 		return details;
 	}
 
 	/**
-	 * Returns <code>true</code> if this results has html content
-	 * that is available via {@link #getHtmlContent()}
+	 * Returns <code>true</code> if this results has html content that is
+	 * available via {@link #getHtmlContent()}
 	 */
 	protected boolean hasHtmlContent() {
 		return pageCounts != null && pageCounts.contentFile != null;

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
@@ -19,12 +19,10 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 
-public class FitnesseResults extends TabulatedResult implements
-		Comparable<FitnesseResults> {
+public class FitnesseResults extends TabulatedResult implements Comparable<FitnesseResults> {
 	private static final String DETAILS = "Details";
 
-	// private static final Logger log =
-	// Logger.getLogger(FitnesseResults.class.getName());
+	//private static final Logger log = Logger.getLogger(FitnesseResults.class.getName());
 
 	private static final long serialVersionUID = 1L;
 	private transient List<FitnesseResults> failed;
@@ -62,8 +60,7 @@ public class FitnesseResults extends TabulatedResult implements
 	}
 
 	/**
-	 * {@link TestObject} Required to compare builds with one another e.g. show
-	 * history graph
+	 * {@link TestObject} Required to compare builds with one another e.g. show history graph
 	 */
 	@Override
 	public TestResult findCorrespondingResult(final String id) {
@@ -193,8 +190,7 @@ public class FitnesseResults extends TabulatedResult implements
 
 	public boolean isEarlierThan(FitnesseResults other) {
 		try {
-			return pageCounts.resultsDateAsDate().before(
-					other.pageCounts.resultsDateAsDate());
+			return pageCounts.resultsDateAsDate().before(other.pageCounts.resultsDateAsDate());
 		} catch (ParseException e) {
 			return false;
 		}
@@ -202,8 +198,7 @@ public class FitnesseResults extends TabulatedResult implements
 
 	public boolean isLaterThan(FitnesseResults other) {
 		try {
-			return pageCounts.resultsDateAsDate().after(
-					other.pageCounts.resultsDateAsDate());
+			return pageCounts.resultsDateAsDate().after(other.pageCounts.resultsDateAsDate());
 		} catch (ParseException e) {
 			return false;
 		}
@@ -211,8 +206,7 @@ public class FitnesseResults extends TabulatedResult implements
 
 	public long millisAfter(FitnesseResults other) {
 		try {
-			return pageCounts.resultsDateAsDate().getTime()
-					- other.pageCounts.resultsDateAsDate().getTime();
+			return pageCounts.resultsDateAsDate().getTime() - other.pageCounts.resultsDateAsDate().getTime();
 		} catch (ParseException e) {
 			return 0;
 		}
@@ -226,9 +220,9 @@ public class FitnesseResults extends TabulatedResult implements
 	}
 
 	/**
-	 * {@see TestObject#getTestResultAction()} Required to prevent looking for
-	 * any old AbstractTestResultAction when e.g. looking for history across
-	 * multiple builds
+	 * {@see TestObject#getTestResultAction()}
+	 * Required to prevent looking for any old AbstractTestResultAction
+	 * when e.g. looking for history across multiple builds 
 	 */
 	@Override
 	public FitnesseResultsAction getTestResultAction() {
@@ -236,14 +230,13 @@ public class FitnesseResults extends TabulatedResult implements
 	}
 
 	/**
-	 * {@see TestResult#getParentAction()} Required to prevent looking for any
-	 * old AbstractTestResultAction when e.g. looking for history across
-	 * multiple builds
+	 * {@see TestResult#getParentAction()}
+	 * Required to prevent looking for any old AbstractTestResultAction
+	 * when e.g. looking for history across multiple builds 
 	 */
 	@Override
 	public FitnesseResultsAction getParentAction() {
-		FitnesseResultsAction action = getOwner().getAction(
-				FitnesseResultsAction.class);
+		FitnesseResultsAction action = getOwner().getAction(FitnesseResultsAction.class);
 		return action;
 	}
 
@@ -293,8 +286,7 @@ public class FitnesseResults extends TabulatedResult implements
 		return skipped;
 	}
 
-	private List<FitnesseResults> filteredCopyOfDetails(
-			ResultsFilter countsFilter) {
+	private List<FitnesseResults> filteredCopyOfDetails(ResultsFilter countsFilter) {
 		List<FitnesseResults> filteredCopy = new ArrayList<FitnesseResults>();
 		for (FitnesseResults result : details) {
 			if (countsFilter.include(result)) {
@@ -313,49 +305,43 @@ public class FitnesseResults extends TabulatedResult implements
 	 * referenced in body.jelly
 	 */
 	public String toHtml(FitnesseResults results) {
-		FitnesseBuildAction buildAction = getOwner().getAction(
-				FitnesseBuildAction.class);
+		FitnesseBuildAction buildAction = getOwner().getAction(FitnesseBuildAction.class);
 		if (buildAction == null) {
 			buildAction = FitnesseBuildAction.NULL_ACTION;
 		}
-		return buildAction.getLinkFor(results.getName(), Hudson.getInstance()
-				.getRootUrl());
+		return buildAction.getLinkFor(results.getName(), Hudson.getInstance().getRootUrl());
 	}
 
 	/**
-	 * referenced in body.jelly. Link is apparently relative to This is the left
-	 * column, which reads the results from file
+	 * referenced in body.jelly. Link is apparently relative to 
+	 * This is the left column, which reads the results from file
 	 */
 	public String getDetailsLink() {
 		if (details == null) {
 			return "&nbsp;";
 		}
 
-		return String.format("<a href=\"%s/%s\">%s</a>", getName(), DETAILS,
-				"Details");
+		return String.format("<a href=\"%s/%s\">%s</a>", getName(), DETAILS, "Details");
 	}
 
 	/**
-	 * referenced in body.jelly. The link points to the history of the fitnesse
-	 * server. Note the history may not always be available.
+	 * referenced in body.jelly. 
+	 * The link points to the history of the fitnesse server. Note the history may not always be available.
 	 */
 	public String getDetailRemoteLink() {
-		FitnesseBuildAction buildAction = getOwner().getAction(
-				FitnesseBuildAction.class);
+		FitnesseBuildAction buildAction = getOwner().getAction(FitnesseBuildAction.class);
 		if (buildAction == null) {
 			buildAction = FitnesseBuildAction.NULL_ACTION;
 		}
-		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate="
-				+ getResultsDate(), null, "Details");
+		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate=" + getResultsDate(), null, "Details");
 	}
 
 	/**
-	 * called from links embedded in history/trend graphs TODO: Expose
-	 * sub-suites as separate elements of the fitnesse report.
+	 * called from links embedded in history/trend graphs 
+	 * TODO: Expose sub-suites as separate elements of the fitnesse report.
 	 */
 	@Override
-	public Object getDynamic(String token, StaplerRequest req,
-			StaplerResponse rsp) {
+	public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
 		TestResult result = findCorrespondingResult(token);
 		if (result != null) {
 			return result;
@@ -376,9 +362,9 @@ public class FitnesseResults extends TabulatedResult implements
 	}
 
 	/**
-	 * Returns <code>true</code> if there are child results available. So far,
-	 * only returns <code>true</code> if there is {@link #getHtmlContent()} for
-	 * this result available.
+	 * Returns <code>true</code> if there are child results available.
+	 * So far, only returns <code>true</code> if there is {@link #getHtmlContent()}
+	 * for this result available.
 	 */
 	@Override
 	public boolean hasChildren() {
@@ -386,9 +372,8 @@ public class FitnesseResults extends TabulatedResult implements
 	}
 
 	/**
-	 * Returns the children of this result. Returns both the details and the
-	 * html content, if available.
-	 * 
+	 * Returns the children of this result. Returns both the details and the html
+	 * content, if available.
 	 * @return the details and html content results, or an empty Collection
 	 */
 	@Override
@@ -406,24 +391,22 @@ public class FitnesseResults extends TabulatedResult implements
 	}
 
 	/**
-	 * Returns <code>true</code> if there are children FitNesse results
-	 * available
+	 * Returns <code>true</code> if there are children FitNesse results available
 	 */
 	protected boolean hasChildResults() {
 		return !getChildResults().isEmpty();
 	}
 
 	/**
-	 * Returns the children FitNesse results that were added with
-	 * {@link #addChild(FitnesseResults)}
+	 * Returns the children FitNesse results that were added with {@link #addChild(FitnesseResults)}
 	 */
 	protected List<FitnesseResults> getChildResults() {
 		return details;
 	}
 
 	/**
-	 * Returns <code>true</code> if this results has html content that is
-	 * available via {@link #getHtmlContent()}
+	 * Returns <code>true</code> if this results has html content
+	 * that is available via {@link #getHtmlContent()}
 	 */
 	protected boolean hasHtmlContent() {
 		return pageCounts != null && pageCounts.contentFile != null;

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResultsRecorder.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResultsRecorder.java
@@ -21,8 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -139,12 +137,9 @@ public class FitnesseResultsRecorder extends Recorder {
 					+ resultsFile.getRemote());
 			resultsInputStream = resultsFile.read();
 
-			Path p = Paths.get(resultsFile.getRemote());
-			String resultFileName = p.getFileName().toString();
-			
 			logger.println("Parsing results... ");
 			NativePageCountsParser pageCountsParser = new NativePageCountsParser();
-			NativePageCounts pageCounts = pageCountsParser.parse(resultsInputStream, resultFileName, logger, rootDir.getAbsolutePath()
+			NativePageCounts pageCounts = pageCountsParser.parse(resultsInputStream, logger, rootDir.getAbsolutePath()
 					+ System.getProperty("file.separator"));
 			logger.println("resultsFile: " + getFitnessePathToXmlResultsIn());
 

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResultsRecorder.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResultsRecorder.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -137,9 +139,12 @@ public class FitnesseResultsRecorder extends Recorder {
 					+ resultsFile.getRemote());
 			resultsInputStream = resultsFile.read();
 
+			Path p = Paths.get(resultsFile.getRemote());
+			String resultFileName = p.getFileName().toString();
+			
 			logger.println("Parsing results... ");
 			NativePageCountsParser pageCountsParser = new NativePageCountsParser();
-			NativePageCounts pageCounts = pageCountsParser.parse(resultsInputStream, logger, rootDir.getAbsolutePath()
+			NativePageCounts pageCounts = pageCountsParser.parse(resultsInputStream, resultFileName, logger, rootDir.getAbsolutePath()
 					+ System.getProperty("file.separator"));
 			logger.println("resultsFile: " + getFitnessePathToXmlResultsIn());
 

--- a/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
+++ b/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
@@ -36,10 +36,12 @@ public class NativePageCounts extends DefaultHandler {
 
 	private final String rootDirName;
 	private final PrintStream logger;
+	private final String resultFileName;
 
-	public NativePageCounts(PrintStream logger, String rootDirName) {
+	public NativePageCounts(PrintStream logger, String resultFileName, String rootDirName) {
 		this.logger = logger;
 		this.rootDirName = rootDirName;
+		this.resultFileName = resultFileName;
 		logger.println("Write fitnesse results to: " + rootDirName);
 	}
 
@@ -59,7 +61,7 @@ public class NativePageCounts extends DefaultHandler {
 		if (COUNTABLE.contains(qName)) {
 			String targetPage;
 			if (qName.equals(SUMMARY)) {
-				targetPage = "Summary";
+				targetPage = resultFileName;
 			} else {
 				String page = attributes.getValue(PAGE);
 				String pseudoPage = attributes.getValue(PSEUDO_PAGE);

--- a/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
+++ b/src/main/java/hudson/plugins/fitnesse/NativePageCounts.java
@@ -36,12 +36,10 @@ public class NativePageCounts extends DefaultHandler {
 
 	private final String rootDirName;
 	private final PrintStream logger;
-	private final String resultFileName;
 
-	public NativePageCounts(PrintStream logger, String resultFileName, String rootDirName) {
+	public NativePageCounts(PrintStream logger, String rootDirName) {
 		this.logger = logger;
 		this.rootDirName = rootDirName;
-		this.resultFileName = resultFileName;
 		logger.println("Write fitnesse results to: " + rootDirName);
 	}
 
@@ -61,7 +59,7 @@ public class NativePageCounts extends DefaultHandler {
 		if (COUNTABLE.contains(qName)) {
 			String targetPage;
 			if (qName.equals(SUMMARY)) {
-				targetPage = resultFileName;
+				targetPage = "Summary";
 			} else {
 				String page = attributes.getValue(PAGE);
 				String pseudoPage = attributes.getValue(PSEUDO_PAGE);

--- a/src/main/java/hudson/plugins/fitnesse/NativePageCountsParser.java
+++ b/src/main/java/hudson/plugins/fitnesse/NativePageCountsParser.java
@@ -12,9 +12,9 @@ import javax.xml.transform.stream.StreamSource;
 
 public class NativePageCountsParser {
 
-	public NativePageCounts parse(InputStream inputStream, String resultFileName, PrintStream logger, String rootDirName)
+	public NativePageCounts parse(InputStream inputStream, PrintStream logger, String rootDirName)
 			throws TransformerException, IOException {
-		NativePageCounts fitnessePageCounts = new NativePageCounts(logger, resultFileName, rootDirName);
+		NativePageCounts fitnessePageCounts = new NativePageCounts(logger, rootDirName);
 		SAXResult intermediateResult = new SAXResult(fitnessePageCounts);
 		transformRawResults(inputStream, intermediateResult);
 		return fitnessePageCounts;

--- a/src/main/java/hudson/plugins/fitnesse/NativePageCountsParser.java
+++ b/src/main/java/hudson/plugins/fitnesse/NativePageCountsParser.java
@@ -12,9 +12,9 @@ import javax.xml.transform.stream.StreamSource;
 
 public class NativePageCountsParser {
 
-	public NativePageCounts parse(InputStream inputStream, PrintStream logger, String rootDirName)
+	public NativePageCounts parse(InputStream inputStream, String resultFileName, PrintStream logger, String rootDirName)
 			throws TransformerException, IOException {
-		NativePageCounts fitnessePageCounts = new NativePageCounts(logger, rootDirName);
+		NativePageCounts fitnessePageCounts = new NativePageCounts(logger, resultFileName, rootDirName);
 		SAXResult intermediateResult = new SAXResult(fitnessePageCounts);
 		transformRawResults(inputStream, intermediateResult);
 		return fitnessePageCounts;

--- a/src/test/java/hudson/plugins/fitnesse/NativePageCountsParserTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/NativePageCountsParserTest.java
@@ -20,9 +20,11 @@ public class NativePageCountsParserTest {
 	private static final String TEST_RESULTS_FINAL_COUNTS = "<finalCounts><right>5</right><wrong>4</wrong><ignores>3</ignores><exceptions>2</exceptions></finalCounts>";
 	private static final String TEST_RESULTS_TOTAL_DURATION = "<totalRunTimeInMillis>2</totalRunTimeInMillis>";
 	private static final String TEST_RESULTS_TAIL = "</testResults>";
-	private static final String RESULTS = TEST_RESULTS_HEAD + PAGE_RESULTS_HEAD + PAGE_RESULTS_COUNTS
-			+ PAGE_RESULTS_DURATION + PAGE_RESULTS_CONTENT + PAGE_RESULTS_NAME + PAGE_RESULTS_HISTORY + PAGE_RESULTS_TAIL
-			+ TEST_RESULTS_FINAL_COUNTS + TEST_RESULTS_TOTAL_DURATION + TEST_RESULTS_TAIL;
+	private static final String RESULTS = TEST_RESULTS_HEAD + PAGE_RESULTS_HEAD
+			+ PAGE_RESULTS_COUNTS + PAGE_RESULTS_DURATION
+			+ PAGE_RESULTS_CONTENT + PAGE_RESULTS_NAME + PAGE_RESULTS_HISTORY
+			+ PAGE_RESULTS_TAIL + TEST_RESULTS_FINAL_COUNTS
+			+ TEST_RESULTS_TOTAL_DURATION + TEST_RESULTS_TAIL;
 	private final NativePageCountsParser fitnesseParser;
 
 	public NativePageCountsParserTest() throws Exception {
@@ -32,28 +34,35 @@ public class NativePageCountsParserTest {
 	}
 
 	@Test
-	public void transformRawResultsShouldProduceSomethingUsable() throws Exception {
+	public void transformRawResultsShouldProduceSomethingUsable()
+			throws Exception {
 		DOMResult domResult = new DOMResult();
 		fitnesseParser.transformRawResults(toInputStream(RESULTS), domResult);
 		Assert.assertNotNull(domResult.getNode());
 		Assert.assertNotNull(domResult.getNode().getFirstChild());
-		Assert.assertEquals("hudson-fitnesse-plugin-report", domResult.getNode().getFirstChild().getNodeName());
+		Assert.assertEquals("hudson-fitnesse-plugin-report", domResult
+				.getNode().getFirstChild().getNodeName());
 	}
 
 	@Test
 	public void transformRawResultsShouldIgnoreBOM() throws Exception {
 		DOMResult domResult = new DOMResult();
-		fitnesseParser.transformRawResults(toInputStream(InputStreamDeBOMer.UTF32BE_BOM, RESULTS.getBytes()), domResult);
+		fitnesseParser.transformRawResults(
+				toInputStream(InputStreamDeBOMer.UTF32BE_BOM,
+						RESULTS.getBytes()), domResult);
 		Assert.assertNotNull(domResult.getNode());
 		Assert.assertNotNull(domResult.getNode().getFirstChild());
-		Assert.assertEquals("hudson-fitnesse-plugin-report", domResult.getNode().getFirstChild().getNodeName());
+		Assert.assertEquals("hudson-fitnesse-plugin-report", domResult
+				.getNode().getFirstChild().getNodeName());
 	}
 
 	@Test
 	public void parserShouldCollectFinalCounts() throws Exception {
-		NativePageCounts testResults = fitnesseParser.parse(toInputStream(RESULTS), System.out, "./target/");
+		NativePageCounts testResults = fitnesseParser.parse(
+				toInputStream(RESULTS), "testResult.xml", System.out,
+				"./target/");
 		Assert.assertEquals(2, testResults.size());
-		Assert.assertEquals("Summary", testResults.getSummary().page);
+		Assert.assertEquals("testResult.xml", testResults.getSummary().page);
 		Assert.assertEquals(5, testResults.getSummary().right);
 		Assert.assertEquals(4, testResults.getSummary().wrong);
 		Assert.assertEquals(3, testResults.getSummary().ignored);
@@ -62,18 +71,22 @@ public class NativePageCountsParserTest {
 
 	@Test
 	public void parserShouldCollectContents() throws Exception {
-		NativePageCounts testResults = fitnesseParser.parse(toInputStream(RESULTS), System.out, "./target/");
+		NativePageCounts testResults = fitnesseParser.parse(
+				toInputStream(RESULTS), "testResult.xml", System.out,
+				"./target/");
 		Assert.assertEquals(2, testResults.size());
-		Assert.assertEquals("Summary", testResults.getSummary().page);
+		Assert.assertEquals("testResult.xml", testResults.getSummary().page);
 		Assert.assertEquals(1, testResults.getDetails().size());
 	}
 
 	@Test
 	public void parserShouldCollectAllCountsFromSuiteFile() throws Exception {
-		InputStream sampleXml = getClass().getResourceAsStream("fitnesse-suite-results.xml");
-		NativePageCounts testResults = fitnesseParser.parse(sampleXml, System.out, "./target/");
+		InputStream sampleXml = getClass().getResourceAsStream(
+				"fitnesse-suite-results.xml");
+		NativePageCounts testResults = fitnesseParser.parse(sampleXml,
+				"testResult.xml", System.out, "./target/");
 		Assert.assertEquals(15, testResults.size());
-		Assert.assertEquals("Summary", testResults.getSummary().page);
+		Assert.assertEquals("testResult.xml", testResults.getSummary().page);
 		Assert.assertEquals(6, testResults.getSummary().right);
 		Assert.assertEquals(5, testResults.getSummary().wrong);
 		Assert.assertEquals(1, testResults.getSummary().ignored);
@@ -82,9 +95,12 @@ public class NativePageCountsParserTest {
 	}
 
 	@Test
-	public void parserShouldCollectAllCountsFromSingleTestFile() throws Exception {
-		InputStream sampleXml = getClass().getResourceAsStream("fitnesse-test-results.xml");
-		NativePageCounts testResults = fitnesseParser.parse(sampleXml, System.out, "./target/");
+	public void parserShouldCollectAllCountsFromSingleTestFile()
+			throws Exception {
+		InputStream sampleXml = getClass().getResourceAsStream(
+				"fitnesse-test-results.xml");
+		NativePageCounts testResults = fitnesseParser.parse(sampleXml,
+				"testResult.xml", System.out, "./target/");
 		Assert.assertEquals(2, testResults.size());
 		Assert.assertEquals("TestDecisionTable", testResults.getSummary().page);
 		Assert.assertEquals(16, testResults.getSummary().right);

--- a/src/test/java/hudson/plugins/fitnesse/NativePageCountsParserTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/NativePageCountsParserTest.java
@@ -20,11 +20,9 @@ public class NativePageCountsParserTest {
 	private static final String TEST_RESULTS_FINAL_COUNTS = "<finalCounts><right>5</right><wrong>4</wrong><ignores>3</ignores><exceptions>2</exceptions></finalCounts>";
 	private static final String TEST_RESULTS_TOTAL_DURATION = "<totalRunTimeInMillis>2</totalRunTimeInMillis>";
 	private static final String TEST_RESULTS_TAIL = "</testResults>";
-	private static final String RESULTS = TEST_RESULTS_HEAD + PAGE_RESULTS_HEAD
-			+ PAGE_RESULTS_COUNTS + PAGE_RESULTS_DURATION
-			+ PAGE_RESULTS_CONTENT + PAGE_RESULTS_NAME + PAGE_RESULTS_HISTORY
-			+ PAGE_RESULTS_TAIL + TEST_RESULTS_FINAL_COUNTS
-			+ TEST_RESULTS_TOTAL_DURATION + TEST_RESULTS_TAIL;
+	private static final String RESULTS = TEST_RESULTS_HEAD + PAGE_RESULTS_HEAD + PAGE_RESULTS_COUNTS
+			+ PAGE_RESULTS_DURATION + PAGE_RESULTS_CONTENT + PAGE_RESULTS_NAME + PAGE_RESULTS_HISTORY + PAGE_RESULTS_TAIL
+			+ TEST_RESULTS_FINAL_COUNTS + TEST_RESULTS_TOTAL_DURATION + TEST_RESULTS_TAIL;
 	private final NativePageCountsParser fitnesseParser;
 
 	public NativePageCountsParserTest() throws Exception {
@@ -34,35 +32,28 @@ public class NativePageCountsParserTest {
 	}
 
 	@Test
-	public void transformRawResultsShouldProduceSomethingUsable()
-			throws Exception {
+	public void transformRawResultsShouldProduceSomethingUsable() throws Exception {
 		DOMResult domResult = new DOMResult();
 		fitnesseParser.transformRawResults(toInputStream(RESULTS), domResult);
 		Assert.assertNotNull(domResult.getNode());
 		Assert.assertNotNull(domResult.getNode().getFirstChild());
-		Assert.assertEquals("hudson-fitnesse-plugin-report", domResult
-				.getNode().getFirstChild().getNodeName());
+		Assert.assertEquals("hudson-fitnesse-plugin-report", domResult.getNode().getFirstChild().getNodeName());
 	}
 
 	@Test
 	public void transformRawResultsShouldIgnoreBOM() throws Exception {
 		DOMResult domResult = new DOMResult();
-		fitnesseParser.transformRawResults(
-				toInputStream(InputStreamDeBOMer.UTF32BE_BOM,
-						RESULTS.getBytes()), domResult);
+		fitnesseParser.transformRawResults(toInputStream(InputStreamDeBOMer.UTF32BE_BOM, RESULTS.getBytes()), domResult);
 		Assert.assertNotNull(domResult.getNode());
 		Assert.assertNotNull(domResult.getNode().getFirstChild());
-		Assert.assertEquals("hudson-fitnesse-plugin-report", domResult
-				.getNode().getFirstChild().getNodeName());
+		Assert.assertEquals("hudson-fitnesse-plugin-report", domResult.getNode().getFirstChild().getNodeName());
 	}
 
 	@Test
 	public void parserShouldCollectFinalCounts() throws Exception {
-		NativePageCounts testResults = fitnesseParser.parse(
-				toInputStream(RESULTS), "testResult.xml", System.out,
-				"./target/");
+		NativePageCounts testResults = fitnesseParser.parse(toInputStream(RESULTS), System.out, "./target/");
 		Assert.assertEquals(2, testResults.size());
-		Assert.assertEquals("testResult.xml", testResults.getSummary().page);
+		Assert.assertEquals("Summary", testResults.getSummary().page);
 		Assert.assertEquals(5, testResults.getSummary().right);
 		Assert.assertEquals(4, testResults.getSummary().wrong);
 		Assert.assertEquals(3, testResults.getSummary().ignored);
@@ -71,22 +62,18 @@ public class NativePageCountsParserTest {
 
 	@Test
 	public void parserShouldCollectContents() throws Exception {
-		NativePageCounts testResults = fitnesseParser.parse(
-				toInputStream(RESULTS), "testResult.xml", System.out,
-				"./target/");
+		NativePageCounts testResults = fitnesseParser.parse(toInputStream(RESULTS), System.out, "./target/");
 		Assert.assertEquals(2, testResults.size());
-		Assert.assertEquals("testResult.xml", testResults.getSummary().page);
+		Assert.assertEquals("Summary", testResults.getSummary().page);
 		Assert.assertEquals(1, testResults.getDetails().size());
 	}
 
 	@Test
 	public void parserShouldCollectAllCountsFromSuiteFile() throws Exception {
-		InputStream sampleXml = getClass().getResourceAsStream(
-				"fitnesse-suite-results.xml");
-		NativePageCounts testResults = fitnesseParser.parse(sampleXml,
-				"testResult.xml", System.out, "./target/");
+		InputStream sampleXml = getClass().getResourceAsStream("fitnesse-suite-results.xml");
+		NativePageCounts testResults = fitnesseParser.parse(sampleXml, System.out, "./target/");
 		Assert.assertEquals(15, testResults.size());
-		Assert.assertEquals("testResult.xml", testResults.getSummary().page);
+		Assert.assertEquals("Summary", testResults.getSummary().page);
 		Assert.assertEquals(6, testResults.getSummary().right);
 		Assert.assertEquals(5, testResults.getSummary().wrong);
 		Assert.assertEquals(1, testResults.getSummary().ignored);
@@ -95,12 +82,9 @@ public class NativePageCountsParserTest {
 	}
 
 	@Test
-	public void parserShouldCollectAllCountsFromSingleTestFile()
-			throws Exception {
-		InputStream sampleXml = getClass().getResourceAsStream(
-				"fitnesse-test-results.xml");
-		NativePageCounts testResults = fitnesseParser.parse(sampleXml,
-				"testResult.xml", System.out, "./target/");
+	public void parserShouldCollectAllCountsFromSingleTestFile() throws Exception {
+		InputStream sampleXml = getClass().getResourceAsStream("fitnesse-test-results.xml");
+		NativePageCounts testResults = fitnesseParser.parse(sampleXml, System.out, "./target/");
 		Assert.assertEquals(2, testResults.size());
 		Assert.assertEquals("TestDecisionTable", testResults.getSummary().page);
 		Assert.assertEquals(16, testResults.getSummary().right);

--- a/src/test/java/hudson/plugins/fitnesse/NativePageCountsTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/NativePageCountsTest.java
@@ -42,21 +42,21 @@ public class NativePageCountsTest {
 
 	@Test
 	public void resultsDateOfShouldStripAnyTrailingGooFromApproxDate() {
-		NativePageCounts results = new NativePageCounts(System.out, "testResult.xml", "./target/");
+		NativePageCounts results = new NativePageCounts(System.out, "./target/");
 		Assert.assertEquals("abc", results.resultsDateOf("abc&amp;"));
 		Assert.assertEquals("abc", results.resultsDateOf("abc"));
 	}
 
 	@Test
 	public void resultsShouldCollectSummaryFromAttributes() {
-		NativePageCounts results = new NativePageCounts(System.out, "testResult.xml", "./target/");
+		NativePageCounts results = new NativePageCounts(System.out, "./target/");
 		AttributesImpl attributes = new AttributesImpl();
 		addSummaryAttributes(attributes, "1", "2", "3", "4", "5");
 		results.startElement("", "", NativePageCounts.SUMMARY, attributes);
 		Assert.assertEquals(1, results.size());
 		Assert.assertNotNull(results.getSummary());
 		Assert.assertEquals(0, results.getDetails().size());
-		Assert.assertEquals("testResult.xml", results.getSummary().page);
+		Assert.assertEquals("Summary", results.getSummary().page);
 		Assert.assertEquals("", results.getSummary().resultsDate);
 		Assert.assertEquals(1, results.getSummary().right);
 		Assert.assertEquals(2, results.getSummary().wrong);
@@ -78,7 +78,7 @@ public class NativePageCountsTest {
 
 	@Test
 	public void resultsShouldCollectDetailFromAttributes() {
-		NativePageCounts results = new NativePageCounts(System.out, "testResult.xml", "./target/");
+		NativePageCounts results = new NativePageCounts(System.out, "./target/");
 		AttributesImpl attributes = new AttributesImpl();
 		attributes.addAttribute("", "", NativePageCounts.PAGE, "String", "name");
 		String resultsDate = "20100311210804";
@@ -109,7 +109,7 @@ public class NativePageCountsTest {
 
 	@Test
 	public void resultsOfTestShouldCollectSummaryFromDetail() {
-		NativePageCounts results = new NativePageCounts(System.out, "testResult.xml", "./target/");
+		NativePageCounts results = new NativePageCounts(System.out, "./target/");
 		AttributesImpl attributes = new AttributesImpl();
 		attributes.addAttribute("", "", NativePageCounts.PAGE, "String", "name");
 		String resultsDate = "20100311210804";

--- a/src/test/java/hudson/plugins/fitnesse/NativePageCountsTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/NativePageCountsTest.java
@@ -42,21 +42,21 @@ public class NativePageCountsTest {
 
 	@Test
 	public void resultsDateOfShouldStripAnyTrailingGooFromApproxDate() {
-		NativePageCounts results = new NativePageCounts(System.out, "./target/");
+		NativePageCounts results = new NativePageCounts(System.out, "testResult.xml", "./target/");
 		Assert.assertEquals("abc", results.resultsDateOf("abc&amp;"));
 		Assert.assertEquals("abc", results.resultsDateOf("abc"));
 	}
 
 	@Test
 	public void resultsShouldCollectSummaryFromAttributes() {
-		NativePageCounts results = new NativePageCounts(System.out, "./target/");
+		NativePageCounts results = new NativePageCounts(System.out, "testResult.xml", "./target/");
 		AttributesImpl attributes = new AttributesImpl();
 		addSummaryAttributes(attributes, "1", "2", "3", "4", "5");
 		results.startElement("", "", NativePageCounts.SUMMARY, attributes);
 		Assert.assertEquals(1, results.size());
 		Assert.assertNotNull(results.getSummary());
 		Assert.assertEquals(0, results.getDetails().size());
-		Assert.assertEquals("Summary", results.getSummary().page);
+		Assert.assertEquals("testResult.xml", results.getSummary().page);
 		Assert.assertEquals("", results.getSummary().resultsDate);
 		Assert.assertEquals(1, results.getSummary().right);
 		Assert.assertEquals(2, results.getSummary().wrong);
@@ -78,7 +78,7 @@ public class NativePageCountsTest {
 
 	@Test
 	public void resultsShouldCollectDetailFromAttributes() {
-		NativePageCounts results = new NativePageCounts(System.out, "./target/");
+		NativePageCounts results = new NativePageCounts(System.out, "testResult.xml", "./target/");
 		AttributesImpl attributes = new AttributesImpl();
 		attributes.addAttribute("", "", NativePageCounts.PAGE, "String", "name");
 		String resultsDate = "20100311210804";
@@ -109,7 +109,7 @@ public class NativePageCountsTest {
 
 	@Test
 	public void resultsOfTestShouldCollectSummaryFromDetail() {
-		NativePageCounts results = new NativePageCounts(System.out, "./target/");
+		NativePageCounts results = new NativePageCounts(System.out, "testResult.xml", "./target/");
 		AttributesImpl attributes = new AttributesImpl();
 		attributes.addAttribute("", "", NativePageCounts.PAGE, "String", "name");
 		String resultsDate = "20100311210804";


### PR DESCRIPTION
[JENKINS-27936] When few FitNesse test results being published in a single job they renamed into Summary