### PR TITLE
add environment variables support for fitnesse hostname and port

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
@@ -1,12 +1,9 @@
 package hudson.plugins.fitnesse;
 
-import hudson.EnvVars;
 import hudson.model.ModelObject;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.plugins.fitnesse.NativePageCounts.Counts;
-import hudson.slaves.EnvironmentVariablesNodeProperty;
-import hudson.tasks.BuildStep;
 import hudson.tasks.test.TabulatedResult;
 import hudson.tasks.test.TestObject;
 import hudson.tasks.test.TestResult;
@@ -314,11 +311,7 @@ public class FitnesseResults extends TabulatedResult implements
 	 * referenced in body.jelly
 	 */
 	public String toHtml(FitnesseResults results) {
-		FitnesseBuildAction buildAction = getOwner().getAction(
-				FitnesseBuildAction.class);
-		if (buildAction == null) {
-			buildAction = getDefaultFitnesseBuidAction();
-		}
+		FitnesseBuildAction buildAction = getFitnesseBuildAction();
 		return buildAction.getLinkFor(results.getName(), Jenkins.getInstance().getRootUrl());
 	}
 
@@ -340,16 +333,26 @@ public class FitnesseResults extends TabulatedResult implements
 	 * server. Note the history may not always be available.
 	 */
 	public String getDetailRemoteLink() {
-		FitnesseBuildAction buildAction = getOwner().getAction(
-				FitnesseBuildAction.class);
-		if (buildAction == null) {
-			buildAction = getDefaultFitnesseBuidAction();
-		}
+		FitnesseBuildAction buildAction = getFitnesseBuildAction();
 		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate="
 				+ getResultsDate(), null, "Details");
 	}
 
-	private FitnesseBuildAction getDefaultFitnesseBuidAction() {
+	public String getRunTestRemoteLink() {
+		FitnesseBuildAction buildAction = getFitnesseBuildAction();
+		String image = "<img class=\"icon-next icon-md\" title=\"Run Test\" src=\"/static/abafcc7b/images/24x24/next.png\" />";
+		return buildAction.getLinkFor(getName() + "?test", null, image);
+	}
+
+	private FitnesseBuildAction getFitnesseBuildAction() {
+		FitnesseBuildAction buildAction = getOwner().getAction(FitnesseBuildAction.class);
+		if (buildAction == null) {
+			buildAction = getDefaultFitnesseBuildAction();
+		}
+		return buildAction;
+	}
+
+	private FitnesseBuildAction getDefaultFitnesseBuildAction() {
 		final FitnesseBuildAction buildAction;Map<String, String> envVars =  getOwner().getEnvVars();
 		if (envVars.containsKey(FITNESSE_HOSTNAME) && envVars.containsKey(FITNESSE_PORT)) {
             buildAction = new FitnesseBuildAction(false, envVars.get(FITNESSE_HOSTNAME), Integer.valueOf(envVars.get(FITNESSE_PORT)));

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResults.java
@@ -1,18 +1,18 @@
 package hudson.plugins.fitnesse;
 
+import hudson.EnvVars;
 import hudson.model.ModelObject;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.plugins.fitnesse.NativePageCounts.Counts;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.tasks.BuildStep;
 import hudson.tasks.test.TabulatedResult;
 import hudson.tasks.test.TestObject;
 import hudson.tasks.test.TestResult;
 
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import jenkins.model.Jenkins;
 
@@ -23,9 +23,10 @@ import org.kohsuke.stapler.export.Exported;
 public class FitnesseResults extends TabulatedResult implements
 		Comparable<FitnesseResults> {
 	private static final String DETAILS = "Details";
+	private static final String FITNESSE_HOSTNAME = "FITNESSE_HOSTNAME";
+	private static final String FITNESSE_PORT = "FITNESSE_PORT";
 
 	// private static final Logger log = Logger.getLogger(FitnesseResults.class.getName());
-
 	private static final long serialVersionUID = 1L;
 	private transient List<FitnesseResults> failed;
 	private transient List<FitnesseResults> skipped;
@@ -316,7 +317,7 @@ public class FitnesseResults extends TabulatedResult implements
 		FitnesseBuildAction buildAction = getOwner().getAction(
 				FitnesseBuildAction.class);
 		if (buildAction == null) {
-			buildAction = FitnesseBuildAction.NULL_ACTION;
+			buildAction = getDefaultFitnesseBuidAction();
 		}
 		return buildAction.getLinkFor(results.getName(), Jenkins.getInstance().getRootUrl());
 	}
@@ -342,10 +343,20 @@ public class FitnesseResults extends TabulatedResult implements
 		FitnesseBuildAction buildAction = getOwner().getAction(
 				FitnesseBuildAction.class);
 		if (buildAction == null) {
-			buildAction = FitnesseBuildAction.NULL_ACTION;
+			buildAction = getDefaultFitnesseBuidAction();
 		}
 		return buildAction.getLinkFor(getName() + "?pageHistory&resultDate="
 				+ getResultsDate(), null, "Details");
+	}
+
+	private FitnesseBuildAction getDefaultFitnesseBuidAction() {
+		final FitnesseBuildAction buildAction;Map<String, String> envVars =  getOwner().getEnvVars();
+		if (envVars.containsKey(FITNESSE_HOSTNAME) && envVars.containsKey(FITNESSE_PORT)) {
+            buildAction = new FitnesseBuildAction(false, envVars.get(FITNESSE_HOSTNAME), Integer.valueOf(envVars.get(FITNESSE_PORT)));
+        } else {
+            buildAction = FitnesseBuildAction.NULL_ACTION;
+        }
+		return buildAction;
 	}
 
 	/**

--- a/src/main/resources/hudson/plugins/fitnesse/FitnesseResults/body.jelly
+++ b/src/main/resources/hudson/plugins/fitnesse/FitnesseResults/body.jelly
@@ -20,13 +20,16 @@
 				<td class="pane-header">Duration</td>
 				<td class="pane-header">Details-Captured</td>
 				<td class="pane-header">Details-Remote</td>
+				<td class="pane-header">Run</td>
 			</tr>
 		<j:forEach var="r" items="${it.failedTests}">
 			<tr>
 				<td><j:out value="${it.toHtml(r)}"/></td>
 				<td>${r.passCount}</td><td>${r.failOnlyCount}</td><td>${r.ignoredCount}</td><td>${r.exceptionCount}</td>
 				<td>${r.duration}</td>
-				<td><j:out value="${r.getDetailsLink()}"/></td><td><j:out value="${r.getDetailRemoteLink()}"/></td>
+				<td><j:out value="${r.getDetailsLink()}"/></td>
+				<td><j:out value="${r.getDetailRemoteLink()}"/></td>
+				<td><j:out value="${r.getRunTestRemoteLink()}"/></td>
 			</tr>
 		</j:forEach>
 		</table>

--- a/src/main/resources/hudson/plugins/fitnesse/FitnesseResults/body.jelly
+++ b/src/main/resources/hudson/plugins/fitnesse/FitnesseResults/body.jelly
@@ -70,7 +70,8 @@
 				<td>${r.passCount}</td>
 				<td>${r.ignoredCount}</td>
 				<td>${r.duration}</td>
-				<td><j:out value="${r.getDetailsLink()}"/></td><td><j:out value="${r.getDetailRemoteLink()}"/></td>
+				<td><j:out value="${r.getDetailsLink()}"/></td>
+				<td><j:out value="${r.getDetailRemoteLink()}"/></td>
 			</tr>
 			</j:forEach>
 		</table>


### PR DESCRIPTION
Hi,

When jobs define only "Publish Fitnesse report results" on post step (not "Build fitnesse test" step), the result page of fitnesse test doesn't display links to fitnesse tests (only the test names are displayed).

I introduce environment variable to define 2 variable : FITNESSE_HOSTNAME and FITNESSE_PORT. They are used to determine the link to fitnesse tests.