### PR TITLE
Added capability to convert/process fitnesse results as JUnit results

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/ConvertReport.java
+++ b/src/main/java/hudson/plugins/fitnesse/ConvertReport.java
@@ -1,0 +1,86 @@
+package hudson.plugins.fitnesse;
+
+import javax.xml.transform.*;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.File;
+import java.io.Reader;
+import java.io.StringReader;
+
+/**
+ * Created by surat_das on 4/27/2017.
+ */
+public class ConvertReport {
+
+    public static void generateJunitResult(String inputFileName, String outputFileName) throws TransformerException {
+
+        Reader reader = new StringReader(getFitnesseToJunitResultStyle());
+        Source stylesheetSource = new StreamSource(reader);
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        Transformer transformer = factory.newTransformer(stylesheetSource);
+
+        Source inputSource = new StreamSource(new File(inputFileName).getAbsoluteFile());
+        Result outputResult = new StreamResult(new File(outputFileName).getAbsoluteFile());
+
+        transformer.transform(inputSource, outputResult);
+
+    }
+
+    private static String getFitnesseToJunitResultStyle() {
+        return
+                "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
+                        "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n" +
+                        "<xsl:template match=\"/\">\n" +
+                        "  <xsl:element name=\"testsuite\">\n" +
+                        "    <xsl:attribute name=\"tests\">\n" +
+                        "      <xsl:value-of select=\"sum(testResults/finalCounts/*)\" />\n" +
+                        "    </xsl:attribute>\n" +
+                        "    <xsl:attribute name=\"failures\">\n" +
+                        "      <xsl:value-of select=\"testResults/finalCounts/wrong\" />\n" +
+                        "    </xsl:attribute>\n" +
+                        "    <xsl:attribute name=\"disabled\">\n" +
+                        "      <xsl:value-of select=\"testResults/finalCounts/ignores\" />\n" +
+                        "    </xsl:attribute>\n" +
+                        "    <xsl:attribute name=\"errors\">\n" +
+                        "      <xsl:value-of select=\"testResults/finalCounts/exceptions\" />\n" +
+                        "    </xsl:attribute>\n" +
+                        "    <xsl:attribute name=\"name\">AcceptanceTests</xsl:attribute>\n" +
+                        "  <xsl:for-each select=\"testResults/result\">\n" +
+                        "    <xsl:element name=\"testcase\">\n" +
+                        "      <xsl:attribute name=\"classname\">\n" +
+                        "        <xsl:value-of select=\"/testResults/rootPath\" />\n" +
+                        "      </xsl:attribute>\n" +
+                        "      <xsl:attribute name=\"name\">\n" +
+                        "        <xsl:value-of select=\"relativePageName\" />\n" +
+                        "      </xsl:attribute>\n" +
+                        "      <xsl:choose>\n" +
+                        "        <xsl:when test=\"counts/exceptions > 0\">\n" +
+                        "          <xsl:element name=\"error\">\n" +
+                        "            <xsl:attribute name=\"message\">\n" +
+                        "              <xsl:value-of select=\"counts/exceptions\" />\n" +
+                        "              <xsl:text> exceptions thrown</xsl:text>\n" +
+                        "              <xsl:if test=\"counts/wrong > 0\">\n" +
+                        "                <xsl:text> and </xsl:text>\n" +
+                        "                <xsl:value-of select=\"counts/wrong\" />\n" +
+                        "                <xsl:text> assertions failed</xsl:text>\n" +
+                        "              </xsl:if>\n" +
+                        "            </xsl:attribute>\n" +
+                        "          </xsl:element>\n" +
+                        "        </xsl:when>\n" +
+                        "        <xsl:when test=\"counts/wrong > 0\">\n" +
+                        "          <xsl:element name=\"failure\">\n" +
+                        "            <xsl:attribute name=\"message\">\n" +
+                        "              <xsl:value-of select=\"counts/wrong\" />\n" +
+                        "              <xsl:text> assertions failed</xsl:text>\n" +
+                        "            </xsl:attribute>\n" +
+                        "          </xsl:element>\n" +
+                        "        </xsl:when>\n" +
+                        "      </xsl:choose>\n" +
+                        "    </xsl:element>\n" +
+                        "  </xsl:for-each>\n" +
+                        "  </xsl:element>\n" +
+                        "</xsl:template>\n" +
+                        "</xsl:stylesheet>";
+    }
+}

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseBuilder.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseBuilder.java
@@ -42,6 +42,7 @@ public class FitnesseBuilder extends Builder implements SimpleBuildStep {
 	public static final String TARGET_PAGE = "fitnesseTargetPage";
 	public static final String TARGET_IS_SUITE = "fitnesseTargetIsSuite";
 	public static final String PATH_TO_RESULTS = "fitnessePathToXmlResultsOut";
+    public static final String PATH_TO_JUNIT_RESULTS = "fitnessePathToJunitResultsOut";
 	public static final String HTTP_TIMEOUT = "fitnesseHttpTimeout";
 	public static final String TEST_TIMEOUT = "fitnesseTestTimeout";
 	public static final String JAVA_WORKING_DIRECTORY = "fitnesseJavaWorkingDirectory";
@@ -254,6 +255,17 @@ public class FitnesseBuilder extends Builder implements SimpleBuildStep {
 		return getOption(PATH_TO_RESULTS, "fitnesse-results.xml", environment);
 	}
 
+    /**
+     * referenced in config.jelly
+     */
+    public String getFitnessePathToJunitResultsOut() {
+        return getOption(PATH_TO_JUNIT_RESULTS, "");
+    }
+
+    public String getFitnessePathToJunitResultsOut(EnvVars environment) {
+        return getOption(PATH_TO_JUNIT_RESULTS, "", environment);
+    }
+
 	/**
 	 * referenced in config.jelly
 	 */
@@ -407,6 +419,13 @@ public class FitnesseBuilder extends Builder implements SimpleBuildStep {
 			return FormValidation.ok();
 		}
 
+        public FormValidation doCheckFitnessePathToJunitResultsOut(@QueryParameter String value) throws IOException,
+                ServletException {
+            if (value.trim().length() > 0 && !value.endsWith("xml"))
+                return FormValidation.error("File name does not end with 'xml': will be ignored");
+            return FormValidation.ok();
+        }
+
 		/**
 		 * {@link BuildStepDescriptor}
 		 */
@@ -437,12 +456,12 @@ public class FitnesseBuilder extends Builder implements SimpleBuildStep {
 						startFitnesseValue,
 						collectFormData(formData, new String[]{FITNESSE_JDK, JAVA_OPTS, JAVA_WORKING_DIRECTORY, PATH_TO_JAR,
 								PATH_TO_ROOT, FITNESSE_PORT_LOCAL, TARGET_PAGE, TARGET_IS_SUITE, HTTP_TIMEOUT, TEST_TIMEOUT,
-								PATH_TO_RESULTS, FITNESSE_ADDITIONAL_OPTIONS}));
+								PATH_TO_RESULTS, PATH_TO_JUNIT_RESULTS, FITNESSE_ADDITIONAL_OPTIONS}));
 			}
 			return newFitnesseBuilder(
 					startFitnesseValue,
 					collectFormData(formData, new String[]{FITNESSE_HOST, FITNESSE_PORT_REMOTE, FITNESSE_USERNAME, FITNESSE_PASSWORD, FITNESSE_ENABLE_SSL, TARGET_PAGE, TARGET_IS_SUITE,
-							HTTP_TIMEOUT, TEST_TIMEOUT, PATH_TO_RESULTS}));
+							HTTP_TIMEOUT, TEST_TIMEOUT, PATH_TO_RESULTS, PATH_TO_JUNIT_RESULTS}));
 		}
 
 		private FitnesseBuilder newFitnesseBuilder(String startFitnesseValue, Map<String, String> collectedFormData) {

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseExecutor.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseExecutor.java
@@ -62,8 +62,7 @@ public class FitnesseExecutor {
 
 			FilePath resultsFilePath = getFilePath(logger, workspace, builder.getFitnessePathToXmlResultsOut(envVars));
 			String junitResultsFileName = builder.getFitnessePathToJunitResultsOut(envVars);
-			if(junitResultsFileName.trim().length()>1)
-				setFitnessePathToJunitResults(junitResultsFileName.trim());
+			setFitnessePathToJunitResults(junitResultsFileName.trim());
 			readAndWriteFitnesseResults(getFitnessePage(build, true), resultsFilePath);
 			return true;
 		} catch (Throwable t) {

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseExecutor.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseExecutor.java
@@ -33,6 +33,7 @@ public class FitnesseExecutor {
 	private final TaskListener listener;
 
 	private String fitnesseTestId = null;
+    private static String fitnessePathToJunitResults;
 
 	public FitnesseExecutor(FitnesseBuilder builder, TaskListener listener, EnvVars envVars) {
 		this.builder = builder;
@@ -53,6 +54,7 @@ public class FitnesseExecutor {
 			}
 
 			FilePath resultsFilePath = getFilePath(logger, workspace, builder.getFitnessePathToXmlResultsOut(envVars));
+            fitnessePathToJunitResults = builder.getFitnessePathToJunitResultsOut(envVars);
 			readAndWriteFitnesseResults(getFitnessePage(build, true), resultsFilePath);
 			return true;
 		} catch (Throwable t) {
@@ -383,4 +385,27 @@ public class FitnesseExecutor {
 			return new FilePath(fileNameFile);
 		}
 	}
+
+    static FilePath getJunitFilePath(PrintStream logger, FilePath workingDirectory) {
+        if (fitnessePathToJunitResults == null || !fitnessePathToJunitResults.endsWith(".xml"))
+            return null;
+        File fp;
+        //Determine if it is in custom folder or in working directory
+        if (fitnessePathToJunitResults.contains("/") || fitnessePathToJunitResults.contains("\\")) {
+            fp = new File(fitnessePathToJunitResults);
+            //if(fp.getPath().
+        }
+        else
+            fp = new File(workingDirectory + "\\" + fitnessePathToJunitResults);
+
+        //Recreate the file if exists. We want to start on a clean file.
+        if (fp.exists())
+            try {
+                fp.delete();
+                fp.createNewFile();
+            } catch (Exception e) {
+                logger.println("ERROR: Could not re-create the junit file. Ensure that it is not in use and you have write permission.");
+            }
+        return new FilePath(fp);
+    }
 }

--- a/src/main/java/hudson/plugins/fitnesse/FitnesseResultsRecorder.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseResultsRecorder.java
@@ -93,6 +93,14 @@ public class FitnesseResultsRecorder extends Recorder implements SimpleBuildStep
 
 		if (resultsFile.exists()) {
 			// directly configured single file
+			// Also convert the fitnesse result xml file into junit file if required. This will be useful if we want to process as junit result
+			try {
+				FilePath junitFilePath = FitnesseExecutor.getJunitFilePath(logger, workingDirectory);
+				if(junitFilePath !=null)
+				    ConvertReport.generateJunitResult(resultsFile.getRemote(),junitFilePath.getRemote());
+			} catch (TransformerException e) {
+				e.printStackTrace(logger);
+			}
 			return new FilePath[] { resultsFile };
 		} else {
 			// glob

--- a/src/main/resources/hudson/plugins/fitnesse/FitnesseBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/fitnesse/FitnesseBuilder/config.jelly
@@ -126,7 +126,7 @@
 <f:block><em>Output</em></f:block>
 
   <f:entry title="HTTP Timeout (ms)" field="fitnesseHttpTimeout"
-  help="/descriptor/hudson.plugins.fitnesse.FitnesseBuilder/help/httpTimeout"> 
+  help="/descriptor/hudson.plugins.fitnesse.FitnesseBuilder/help/httpTimeout">
     <f:textbox name="fitnesseHttpTimeout" />
   </f:entry>
   
@@ -139,5 +139,10 @@
   help="/descriptor/hudson.plugins.fitnesse.FitnesseResultsRecorder/help/pathToXmlResults">
       <f:textbox name="fitnessePathToXmlResultsOut" />
   </f:entry>
+
+   <f:entry title="JUnit xml filename" field="fitnessePathToJunitResultsOut"
+      help="/descriptor/hudson.plugins.fitnesse.FitnesseBuilder/help/pathToJunitResults">
+          <f:textbox name="fitnessePathToJunitResultsOut" />
+   </f:entry>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/fitnesse/FitnesseBuilder/help-pathToJunitResults.html
+++ b/src/main/resources/hudson/plugins/fitnesse/FitnesseBuilder/help-pathToJunitResults.html
@@ -1,0 +1,4 @@
+<div>
+    Enter file name here if you want Jenkins to convert fitnesse results to Junit results for representing, publishing or processing. Example filename :  fitnesse-result-junit.xml.
+    Currently the file is written to the Jenkins workspace. The resultant file can be used to publish as Junit result or can be processed further like any other junit builds (archiving, generate html report, sending via email etc.).
+</div>

--- a/src/test/java/hudson/plugins/fitnesse/BuilderDescriptorImplTest.java
+++ b/src/test/java/hudson/plugins/fitnesse/BuilderDescriptorImplTest.java
@@ -2,11 +2,10 @@ package hudson.plugins.fitnesse;
 
 import hudson.plugins.fitnesse.FitnesseBuilder.DescriptorImpl;
 import hudson.util.FormValidation.Kind;
-
-import java.io.File;
-
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.File;
 
 public class BuilderDescriptorImplTest {
 	private DescriptorImpl descriptor;
@@ -75,6 +74,21 @@ public class BuilderDescriptorImplTest {
 	@Test
 	public void emptyPathToFitnesseResultsShouldBeError() throws Exception {
 		Assert.assertEquals(Kind.ERROR, descriptor.doCheckFitnessePathToXmlResultsOut("").kind);
+	}
+
+	@Test
+	public void emptyPathToJUnitResultsShouldBeOK() throws Exception {
+		Assert.assertEquals(Kind.OK, descriptor.doCheckFitnessePathToJunitResultsOut("").kind);
+	}
+
+	@Test
+	public void validPathToJUnitResultsShouldBeOK() throws Exception {
+		Assert.assertEquals(Kind.OK, descriptor.doCheckFitnessePathToJunitResultsOut("fitnesse-results-junit.xml").kind);
+	}
+
+	@Test
+	public void invalidPathToJUnitResultsShouldBeWarning() throws Exception {
+		Assert.assertEquals(Kind.ERROR, descriptor.doCheckFitnessePathToJunitResultsOut("al").kind);
 	}
 
 	public void nonExistentFitnesseResultsShouldBeOK() throws Exception {


### PR DESCRIPTION
Many Jenkins users have established infrastructure to run and process JUnit tests results. They will have easier path towards migrating to Fitnesse if we have similar experience. This pull request tries to address this by converting the fitnesse result to JUnit result which can then be picked up by other build or post build tasks. Also, we can publish both the reports (Fitnesse and JUnit) as can be seen in the screenshot
![image](https://cloud.githubusercontent.com/assets/9042580/25551829/efd9b8c4-2c3f-11e7-9f91-36348d7c2c08.png)


