### PR TITLE
Changes to read and write results in distributed Jenkins

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/FitnesseBuilder.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseBuilder.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,7 +25,9 @@ import java.util.Map;
  *
  * @author Tim Bacon
  */
-public class FitnesseBuilder extends Builder implements SimpleBuildStep {
+public class FitnesseBuilder extends Builder implements SimpleBuildStep, Serializable {
+
+        private static final long serialVersionUID = 931934300658830569L;
 
 	public static final String START_FITNESSE = "fitnesseStart";
 	public static final String FITNESSE_HOST = "fitnesseHost";
@@ -42,7 +45,7 @@ public class FitnesseBuilder extends Builder implements SimpleBuildStep {
 	public static final String TARGET_PAGE = "fitnesseTargetPage";
 	public static final String TARGET_IS_SUITE = "fitnesseTargetIsSuite";
 	public static final String PATH_TO_RESULTS = "fitnessePathToXmlResultsOut";
-    public static final String PATH_TO_JUNIT_RESULTS = "fitnessePathToJunitResultsOut";
+	public static final String PATH_TO_JUNIT_RESULTS = "fitnessePathToJunitResultsOut";
 	public static final String HTTP_TIMEOUT = "fitnesseHttpTimeout";
 	public static final String TEST_TIMEOUT = "fitnesseTestTimeout";
 	public static final String JAVA_WORKING_DIRECTORY = "fitnesseJavaWorkingDirectory";


### PR DESCRIPTION
This changes the execution of calls to the FitNesse server, reading and writing results to happen on the Jenkins build node rather than executing on the Jenkins master. Preferable with this implementation in environments where the Jenkins build nodes have access to the FitNesse server but the Jenkins master does not have access to the FitNesse server. Also, it distributes the load for execution to the Jenkins build nodes.