### PR TITLE
HOST_NAME is not picked up in pipeline

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/FitnesseBuilder.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseBuilder.java
@@ -113,7 +113,11 @@ public class FitnesseBuilder extends Builder implements SimpleBuildStep, Seriali
 
 	public String getFitnesseHost(EnvVars environment) {
 		if (getFitnesseStart()) {
-			return _LOCALHOST;
+      if (environment != null && environment.get(_HOSTNAME_SLAVE_PROPERTY) != null) {
+        return environment.get(_HOSTNAME_SLAVE_PROPERTY);
+      } else {
+        return _LOCALHOST;
+      }
 		} else {
 			return getOption(FITNESSE_HOST, "unknown_host", environment);
 		}


### PR DESCRIPTION
While it is possible to execute the fitnesse plugin in a freestyle project on a slave, when you do the exact same using pipeline, the server is always started on localhost. This patch should fix that.

(I have an issue compiling, when I do mvn clean package (or build or test) I get:
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.1:compile (default-compile) on project fitnesse: Compilation failure
[ERROR] java.nio.file.NoSuchFileException: /home/someone/LocalProjects/fitnesse-plugin/target/classes/META-INF/annotations/hudson.Extension

So this is not tested very well.
