### PR TITLE
Fixed : Pages with tags not run when new FitNesse is started.

### DIFF
--- a/src/main/java/hudson/plugins/fitnesse/FitnesseExecutor.java
+++ b/src/main/java/hudson/plugins/fitnesse/FitnesseExecutor.java
@@ -372,7 +372,8 @@ public class FitnesseExecutor implements Serializable {
 		int pos = targetPageExpression.indexOf('?');
 		if (pos == -1)
 			pos = targetPageExpression.length();
-		return "/" + targetPageExpression.substring(0, pos);
+               int posOfAmp = targetPageExpression.contains("&") ? targetPageExpression.indexOf("&") : pos;
+               return "/" + targetPageExpression.substring(0, Math.min(pos, posOfAmp));
 	}
 
 	/* package for test */String getFitnessePageCmd() {

--- a/src/main/resources/hudson/plugins/fitnesse/FitnesseBuilder/help-targetPage.html
+++ b/src/main/resources/hudson/plugins/fitnesse/FitnesseBuilder/help-targetPage.html
@@ -1,4 +1,7 @@
 <div>
-The page to execute as the test target e.g. ParentWiki.SuiteAll or 
-ParentWiki.SuiteAll&amp;suiteFilter=tag1,tag2
+    The page to execute. e.g. ParentWiki.SuiteAll
+    <div>May also include tags. Details at
+        <a href="http://fitnesse.org/FitNesse.FullReferenceGuide.UserGuide.WritingAcceptanceTests.TestSuites.TagsAndFilters">FitNesse Help</a>
+        e.g. ParentWiki.SuiteAll&amp;runTestsMatchingAnyTag=smoke,critical
+    </div>
 </div>


### PR DESCRIPTION
### _Steps to reproduce the issue_
---
    
With this plugin, select to start FitNesse and try to run a page with tags. e.g. `TestSuite&runTestsMatchingAnyTag=smoke,critical`   The build will fail  (see screenshot below). 

<img width="1038" alt="DoesNotRunWhenTagsAdded" src="https://user-images.githubusercontent.com/9042580/149411215-8dbfc059-cdd2-4230-a938-f8f90fb2c1ac.png">

### _Why it fails and what the fix is_
---

&nbsp;&nbsp;&nbsp;&nbsp;The code checks to see if the FitNesse is up and running before it appends the `suite` responder. Because the URL includes `&`, it results in `404` from the FitNesse server causing the build to terminate.

&nbsp;&nbsp;&nbsp;&nbsp;With this pull request, the base page now strips the `&` part to check FitNesse status resulting in a successful build.

### _Checks_
---

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue